### PR TITLE
[SCH-1219] Fix incorrect TypeScript event names

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,8 @@
       ]
     },
     "ignore": [
-      "examples/**/generated/**"
+      "examples/**/generated/**",
+      "**/__snapshots__/**"
     ]
   },
   "husky": {

--- a/src/commands/gen-ts.ts
+++ b/src/commands/gen-ts.ts
@@ -66,11 +66,15 @@ class AJSWrapperRenderer extends TypeScriptRenderer {
         () => {
           this.emitLine('const payload = transform(props, ', typeMap, ', jsToJSONProps, typeMap);')
 
+          const rawEventName = name
+            .proposeUnstyledNames(null)
+            .values()
+            .next().value
           this.emitLine(
             "if (context) { window.analytics.track('",
-            name,
+            rawEventName,
             "', payload, { context }) } else { window.analytics.track('",
-            name,
+            rawEventName,
             "', payload) }"
           )
         }

--- a/tests/commands/ts/__snapshots__/index.ts
+++ b/tests/commands/ts/__snapshots__/index.ts
@@ -290,15 +290,15 @@ export interface RequiredObject {
 
 export function the42TerribleEventName3(props: The42_TerribleEventName3, context?: any): void{
   const payload = transform(props, r("The42_TerribleEventName3"), jsToJSONProps, typeMap);
-  if (context) { window.analytics.track('The42_TerribleEventName3', payload, { context }) } else { window.analytics.track('The42_TerribleEventName3', payload) }
+  if (context) { window.analytics.track('42_--terrible==event++name~!3', payload, { context }) } else { window.analytics.track('42_--terrible==event++name~!3', payload) }
 }
 
 export function emptyEvent(props: { [key: string]: any }, context?: any): void{
   const payload = transform(props, m("any"), jsToJSONProps, typeMap);
-  if (context) { window.analytics.track('EmptyEvent', payload, { context }) } else { window.analytics.track('EmptyEvent', payload) }
+  if (context) { window.analytics.track('Empty Event', payload, { context }) } else { window.analytics.track('Empty Event', payload) }
 }
 
 export function exampleEvent(props: ExampleEvent, context?: any): void{
   const payload = transform(props, r("ExampleEvent"), jsToJSONProps, typeMap);
-  if (context) { window.analytics.track('ExampleEvent', payload, { context }) } else { window.analytics.track('ExampleEvent', payload) }
+  if (context) { window.analytics.track('Example Event', payload, { context }) } else { window.analytics.track('Example Event', payload) }
 }


### PR DESCRIPTION
This PR fixes an issue where an incorrectly formatted event name was used in TypeScript `track()` calls (introduced before we added a testing harness).