### PR TITLE
Fix broken generate-examples script

### DIFF
--- a/examples/android/java/Makefile
+++ b/examples/android/java/Makefile
@@ -10,7 +10,7 @@ build:
 	@cd ${ROOT_PATH} && yarn build
 
 .PHONY: typewriter-remote
-typewriter-remote: build
+typewriter-remote:
 	@echo "Generating Typewriter Android Java client..."
 	@rm -rf ${OUTPUT_PATH}
 	@mkdir -p ${OUTPUT_PATH}
@@ -25,7 +25,7 @@ typewriter-remote: build
 	@echo "Done."
 
 .PHONY: typewriter-local
-typewriter-local: build
+typewriter-local:
 	@echo "Generating Typewriter Android Java client..."
 	@rm -rf ${OUTPUT_PATH}
 	@mkdir -p ${OUTPUT_PATH}

--- a/examples/android/java/README.md
+++ b/examples/android/java/README.md
@@ -21,7 +21,7 @@ The JSON schema used to generate this client is available in [`local-tracking-pl
 You can regenerate the Typewriter client using the following [`make` command](Makefile):
 
 ```sh
-$ make typewriter-local
+$ make build typewriter-local
 ```
 
 ## Instrumentation

--- a/examples/ios/objectivec/Makefile
+++ b/examples/ios/objectivec/Makefile
@@ -10,7 +10,7 @@ build:
 	@cd ${ROOT_PATH} && yarn build
 
 .PHONY: typewriter-remote
-typewriter-remote: build
+typewriter-remote:
 	@echo "Generating Typewriter iOS Objective-C client..."
 	@rm -rf ${OUTPUT_PATH}
 	@mkdir -p ${OUTPUT_PATH}
@@ -24,7 +24,7 @@ typewriter-remote: build
 	@echo "Done."
 
 .PHONY: typewriter-local
-typewriter-local: build
+typewriter-local:
 	@echo "Generating Typewriter iOS Objective-C client..."
 	@rm -rf ${OUTPUT_PATH}
 	@mkdir -p ${OUTPUT_PATH}

--- a/examples/ios/objectivec/README.md
+++ b/examples/ios/objectivec/README.md
@@ -24,7 +24,7 @@ The generated Typewriter client is available in [`TypewriterExample/Analytics`](
 
 The JSON schema used to generate this client is available in [`local-tracking-plans/tracking-plan-mobile.json`](../../local-tracking-plans/tracking-plan-mobile.json).
 
-You can regenerate the Typewriter client with `make typewriter-local`.
+You can regenerate the Typewriter client with `make build typewriter-local`.
 
 ## Instrumentation
 

--- a/examples/js/pages/generated/index.js
+++ b/examples/js/pages/generated/index.js
@@ -5,7 +5,7 @@ const genOptions = (context = { library: {} }) => ({
       ...context.library,
       typewriter: {
         name: "gen-js",
-        version: "3.1.0"
+        version: "3.1.3"
       }
     }
   }

--- a/examples/ts/pages/generated/index.ts
+++ b/examples/ts/pages/generated/index.ts
@@ -148,15 +148,15 @@ export interface ProfileViewed {
 
 export function feedViewed(props: FeedViewed, context?: any): void{
   const payload = transform(props, r("FeedViewed"), jsToJSONProps, typeMap);
-  if (context) { window.analytics.track('FeedViewed', payload, { context }) } else { window.analytics.track('FeedViewed', payload) }
+  if (context) { window.analytics.track('Feed Viewed', payload, { context }) } else { window.analytics.track('Feed Viewed', payload) }
 }
 
 export function photoViewed(props: PhotoViewed, context?: any): void{
   const payload = transform(props, r("PhotoViewed"), jsToJSONProps, typeMap);
-  if (context) { window.analytics.track('PhotoViewed', payload, { context }) } else { window.analytics.track('PhotoViewed', payload) }
+  if (context) { window.analytics.track('Photo Viewed', payload, { context }) } else { window.analytics.track('Photo Viewed', payload) }
 }
 
 export function profileViewed(props: ProfileViewed, context?: any): void{
   const payload = transform(props, r("ProfileViewed"), jsToJSONProps, typeMap);
-  if (context) { window.analytics.track('ProfileViewed', payload, { context }) } else { window.analytics.track('ProfileViewed', payload) }
+  if (context) { window.analytics.track('Profile Viewed', payload, { context }) } else { window.analytics.track('Profile Viewed', payload) }
 }


### PR DESCRIPTION
There was a race condition caused by the Android and iOS examples building (which removes the `dist` folder) and the JS example which reads from `dist/package.json`