### PR TITLE
Fix broken SVG image on npmjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<div align="center">
+<p align="center">
 	<br>
 	<br>
   <img src=".github/assets/typewriter-logo.svg?sanitize=true" alt="Typewriter logo" />
@@ -6,14 +6,14 @@
   <br>
   <br>
   <br>
-</div>
+</p>
 
 
 
-<div align="center">
+<p align="center">
 
 [![CircleCI][circle-badge]][circle-link] [![npm-version][npm-badge]][npm-link] [![license][license-badge]][license-link]
-</div>
+</p>
 
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 	<br>
 	<br>
-  <img src=".github/assets/typewriter-logo.svg" alt="Typewriter logo" />
+  <img src=".github/assets/typewriter-logo.svg?sanitize=true" alt="Typewriter logo" />
   <br>
   <br>
   <br>

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@
 
 
 
-<p align="center">
+<div align="center">
+  <p align="center">
 
-[![CircleCI][circle-badge]][circle-link] [![npm-version][npm-badge]][npm-link] [![license][license-badge]][license-link]
+  [![CircleCI][circle-badge]][circle-link] [![npm-version][npm-badge]][npm-link] [![license][license-badge]][license-link]
+  </p>
 </p>
 
 


### PR DESCRIPTION
Currently:

![image](https://user-images.githubusercontent.com/2907397/47804921-46ee8300-dcf3-11e8-8ef3-96b30afbec9d.png)

Now: :mindblown:
![image](https://user-images.githubusercontent.com/2907397/47805370-6934d080-dcf4-11e8-8f7d-9e0929fefda4.png)

See: https://stackoverflow.com/questions/13808020/include-an-svg-hosted-on-github-in-markdown/21521184#21521184