### PR TITLE
[SCH-1225] Move Typewriter context fields out of library; add to iOS

### DIFF
--- a/examples/ios/objectivec/TypewriterExample/Analytics/SEGKicksAppAnalytics.m
+++ b/examples/ios/objectivec/TypewriterExample/Analytics/SEGKicksAppAnalytics.m
@@ -9,6 +9,27 @@ static id NSNullify(id _Nullable x) {
     return (x == nil || x == NSNull.null) ? NSNull.null : x;
 }
 
+static NSDictionary<NSString *, id> *_Nullable addTypewriterContextFields(NSDictionary<NSString *, id> *_Nullable options) {
+    options = options ?: @{};
+    NSDictionary<NSString *, id> *customContext = options[@"context"] ?: @{};
+    NSDictionary<NSString *, id> *typewriterContext = @{
+                                                        @"typewriter": @{
+                                                                @"name": @"gen-ios",
+                                                                @"version": @"3.2.5"
+                                                                }
+                                                        };
+    NSMutableDictionary *context = [NSMutableDictionary dictionaryWithCapacity:customContext.count + typewriterContext.count];
+    [context addEntriesFromDictionary:customContext];
+    [context addEntriesFromDictionary:typewriterContext];
+    
+    NSMutableDictionary *newOptions = [NSMutableDictionary dictionaryWithCapacity:options.count + 1];
+    [newOptions addEntriesFromDictionary:options];
+    [newOptions addEntriesFromDictionary:@{
+                                           @"context": context
+                                           }];
+    return newOptions;
+}
+
 NS_ASSUME_NONNULL_BEGIN
 
 static id prune(NSDictionary *dict) {
@@ -198,11 +219,11 @@ static id map(id collection, id (^f)(id value)) {
 
 - (void)orderCompleted:(SEGOrderCompleted *)props
 {
-    [self.analytics track:@"Order Completed" properties:[props JSONDictionary]];
+    [self orderCompleted:props withOptions:@{}];
 }
 - (void)orderCompleted:(SEGOrderCompleted *)props withOptions:(NSDictionary<NSString *, id> *_Nullable)options
 {
-    [self.analytics track:@"Order Completed" properties:[props JSONDictionary] options:options];
+    [self.analytics track:@"Order Completed" properties:[props JSONDictionary] options:addTypewriterContextFields(options)];
 }
 @end
 

--- a/examples/ios/objectivec/TypewriterExample/ViewController.m
+++ b/examples/ios/objectivec/TypewriterExample/ViewController.m
@@ -24,9 +24,9 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
+
     self.sentTextView.alpha = 0;
-    
+
     self.kicksAppAnalytics = [[SEGKicksAppAnalytics alloc] initWithAnalytics:[SEGAnalytics sharedAnalytics]];
 }
 
@@ -46,7 +46,7 @@
         builder.products = products;
     }];
     [self.kicksAppAnalytics orderCompleted:order];
-    
+
     self.sentTextView.alpha = 1;
     [UIView animateWithDuration:0.5 delay:1 options:UIViewAnimationOptionCurveEaseIn animations:^{ self.sentTextView.alpha = 0;} completion:nil];
 }

--- a/examples/js/pages/generated/index.js
+++ b/examples/js/pages/generated/index.js
@@ -1,12 +1,9 @@
-const genOptions = (context = { library: {} }) => ({
+const genOptions = (context = {}) => ({
   context: {
     ...context,
-    library: {
-      ...context.library,
-      typewriter: {
-        name: "gen-js",
-        version: "3.2.5"
-      }
+    typewriter: {
+      name: "gen-js",
+      version: "3.2.5"
     }
   }
 });

--- a/examples/node/generated/index.js
+++ b/examples/node/generated/index.js
@@ -1,13 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const genOptions = (context = { library: {} }) => ({
+const genOptions = (context = {}) => ({
   context: Object.assign({}, context, {
-    library: Object.assign({}, context.library, {
-      typewriter: {
-        name: "gen-js",
-        version: "3.2.5"
-      }
-    })
+    typewriter: {
+      name: "gen-js",
+      version: "3.2.5"
+    }
   })
 });
 class Analytics {

--- a/src/commands/gen-js.ts
+++ b/src/commands/gen-js.ts
@@ -65,15 +65,12 @@ export async function genJS(
   ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
 
   const fileHeader = `
-    const genOptions = (context = { library: {} }) => ({
+    const genOptions = (context = {}) => ({
       context: {
         ...context,
-        library: {
-          ...context.library,
-          typewriter: {
-            name: "${command}",
-            version: "${version}"
-          }
+        typewriter: {
+          name: "${command}",
+          version: "${version}"
         }
       }
     })

--- a/tests/commands/ios/__snapshots__/SEGTestTrackingPlanAnalytics.m
+++ b/tests/commands/ios/__snapshots__/SEGTestTrackingPlanAnalytics.m
@@ -9,6 +9,27 @@ static id NSNullify(id _Nullable x) {
     return (x == nil || x == NSNull.null) ? NSNull.null : x;
 }
 
+static NSDictionary<NSString *, id> *_Nullable addTypewriterContextFields(NSDictionary<NSString *, id> *_Nullable options) {
+    options = options ?: @{};
+    NSDictionary<NSString *, id> *customContext = options[@"context"] ?: @{};
+    NSDictionary<NSString *, id> *typewriterContext = @{
+                                                        @"typewriter": @{
+                                                                @"name": @"gen-ios",
+                                                                @"version": @"3.2.5"
+                                                                }
+                                                        };
+    NSMutableDictionary *context = [NSMutableDictionary dictionaryWithCapacity:customContext.count + typewriterContext.count];
+    [context addEntriesFromDictionary:customContext];
+    [context addEntriesFromDictionary:typewriterContext];
+    
+    NSMutableDictionary *newOptions = [NSMutableDictionary dictionaryWithCapacity:options.count + 1];
+    [newOptions addEntriesFromDictionary:options];
+    [newOptions addEntriesFromDictionary:@{
+                                           @"context": context
+                                           }];
+    return newOptions;
+}
+
 NS_ASSUME_NONNULL_BEGIN
 
 static id prune(NSDictionary *dict) {
@@ -455,29 +476,29 @@ static id map(id collection, id (^f)(id value)) {
 
 - (void)the42TerribleEventName3:(SEGThe42_TerribleEventName3 *)props
 {
-    [self.analytics track:@"42_--terrible==event++name~!3" properties:[props JSONDictionary]];
+    [self the42TerribleEventName3:props withOptions:@{}];
 }
 - (void)the42TerribleEventName3:(SEGThe42_TerribleEventName3 *)props withOptions:(NSDictionary<NSString *, id> *_Nullable)options
 {
-    [self.analytics track:@"42_--terrible==event++name~!3" properties:[props JSONDictionary] options:options];
+    [self.analytics track:@"42_--terrible==event++name~!3" properties:[props JSONDictionary] options:addTypewriterContextFields(options)];
 }
 
 - (void)emptyEvent:(SEGEmptyEvent *)props
 {
-    [self.analytics track:@"Empty Event" properties:[props JSONDictionary]];
+    [self emptyEvent:props withOptions:@{}];
 }
 - (void)emptyEvent:(SEGEmptyEvent *)props withOptions:(NSDictionary<NSString *, id> *_Nullable)options
 {
-    [self.analytics track:@"Empty Event" properties:[props JSONDictionary] options:options];
+    [self.analytics track:@"Empty Event" properties:[props JSONDictionary] options:addTypewriterContextFields(options)];
 }
 
 - (void)exampleEvent:(SEGExampleEvent *)props
 {
-    [self.analytics track:@"Example Event" properties:[props JSONDictionary]];
+    [self exampleEvent:props withOptions:@{}];
 }
 - (void)exampleEvent:(SEGExampleEvent *)props withOptions:(NSDictionary<NSString *, id> *_Nullable)options
 {
-    [self.analytics track:@"Example Event" properties:[props JSONDictionary] options:options];
+    [self.analytics track:@"Example Event" properties:[props JSONDictionary] options:addTypewriterContextFields(options)];
 }
 @end
 

--- a/tests/commands/js/__snapshots__/index.amd.js
+++ b/tests/commands/js/__snapshots__/index.amd.js
@@ -1,15 +1,12 @@
 define(["require", "exports"], function(require, exports) {
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
-  const genOptions = (context = { library: {} }) => ({
+  const genOptions = (context = {}) => ({
     context: {
       ...context,
-      library: {
-        ...context.library,
-        typewriter: {
-          name: "gen-js",
-          version: "3.2.5"
-        }
+      typewriter: {
+        name: "gen-js",
+        version: "3.2.5"
       }
     }
   });

--- a/tests/commands/js/__snapshots__/index.js
+++ b/tests/commands/js/__snapshots__/index.js
@@ -1,12 +1,9 @@
-const genOptions = (context = { library: {} }) => ({
+const genOptions = (context = {}) => ({
   context: {
     ...context,
-    library: {
-      ...context.library,
-      typewriter: {
-        name: "gen-js",
-        version: "3.2.5"
-      }
+    typewriter: {
+      name: "gen-js",
+      version: "3.2.5"
     }
   }
 });

--- a/tests/commands/js/__snapshots__/index.node.js
+++ b/tests/commands/js/__snapshots__/index.node.js
@@ -1,13 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const genOptions = (context = { library: {} }) => ({
+const genOptions = (context = {}) => ({
   context: Object.assign({}, context, {
-    library: Object.assign({}, context.library, {
-      typewriter: {
-        name: "gen-js",
-        version: "3.2.5"
-      }
-    })
+    typewriter: {
+      name: "gen-js",
+      version: "3.2.5"
+    }
   })
 });
 class Analytics {

--- a/tests/commands/js/__snapshots__/index.system.js
+++ b/tests/commands/js/__snapshots__/index.system.js
@@ -5,15 +5,12 @@ System.register([], function(exports_1, context_1) {
   return {
     setters: [],
     execute: function() {
-      genOptions = (context = { library: {} }) => ({
+      genOptions = (context = {}) => ({
         context: {
           ...context,
-          library: {
-            ...context.library,
-            typewriter: {
-              name: "gen-js",
-              version: "3.2.5"
-            }
+          typewriter: {
+            name: "gen-js",
+            version: "3.2.5"
           }
         }
       });

--- a/tests/commands/js/__snapshots__/index.umd.js
+++ b/tests/commands/js/__snapshots__/index.umd.js
@@ -8,15 +8,12 @@
 })(function(require, exports) {
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
-  const genOptions = (context = { library: {} }) => ({
+  const genOptions = (context = {}) => ({
     context: {
       ...context,
-      library: {
-        ...context.library,
-        typewriter: {
-          name: "gen-js",
-          version: "3.2.5"
-        }
+      typewriter: {
+        name: "gen-js",
+        version: "3.2.5"
       }
     }
   });


### PR DESCRIPTION
Setting the Typewriter context fields in `library` overwrote the `library.*` fields. This moves those fields in our JS library out to `context.typewriter` and adds these fields to iOS.

Skipping TypeScript for now, since we'll likely update it to use JS in #26 

Skipping Android for now, until https://github.com/segmentio/analytics-android/pull/595 is released in the next analytics-android release