### PR TITLE
Wrap JS client validation with {properties: ...}

### DIFF
--- a/examples/js/pages/generated/index.js
+++ b/examples/js/pages/generated/index.js
@@ -105,7 +105,7 @@ export default class Analytics {
         validate.errors = vErrors;
         return errors === 0;
       };
-      var valid = validate(props);
+      var valid = validate({ properties: props });
       if (!valid) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
@@ -191,7 +191,7 @@ export default class Analytics {
         validate.errors = vErrors;
         return errors === 0;
       };
-      var valid = validate(props);
+      var valid = validate({ properties: props });
       if (!valid) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
@@ -277,7 +277,7 @@ export default class Analytics {
         validate.errors = vErrors;
         return errors === 0;
       };
-      var valid = validate(props);
+      var valid = validate({ properties: props });
       if (!valid) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }

--- a/examples/js/pages/index.js
+++ b/examples/js/pages/index.js
@@ -14,7 +14,7 @@ export default class extends React.Component {
 
   componentDidMount () {
     const appAnalytics = new Analytics(window.analytics)
-    appAnalytics.feedViewed({ profileId: '3' })
+    appAnalytics.feedViewed({ profile_id: '3' })
   }
 
   dismissModal () {

--- a/examples/js/pages/photo.js
+++ b/examples/js/pages/photo.js
@@ -6,7 +6,7 @@ import Analytics from './generated'
 export default class Photo extends React.Component {
   componentDidMount() {
     const appAnalytics = new Analytics(window.analytics)
-    appAnalytics.photoViewed({ photoID: '3' })
+    appAnalytics.photoViewed({ photo_id: '3' })
   }
   render() {
     return (

--- a/examples/js/pages/profile.js
+++ b/examples/js/pages/profile.js
@@ -5,7 +5,7 @@ import Analytics from './generated'
 export default class Profile extends React.Component {
   componentDidMount() {
     const appAnalytics = new Analytics(window.analytics)
-    appAnalytics.profileViewed({ profileId: '3' })
+    appAnalytics.profileViewed({ profile_id: '3' })
   }
   render() {
     return (

--- a/src/commands/gen-js.ts
+++ b/src/commands/gen-js.ts
@@ -109,7 +109,7 @@ export async function genJS(
       if (client === Client.js) {
         parameters = 'props, context'
         trackCall = `this.analytics.track('${name}', props, genOptions(context))`
-        validateCall = 'validate(props)'
+        validateCall = 'validate({ properties: props })'
       } else if (client === Client.node) {
         parameters = 'message, callback'
         trackCall = `

--- a/tests/commands/js/__snapshots__/index.amd.js
+++ b/tests/commands/js/__snapshots__/index.amd.js
@@ -91,7 +91,7 @@ define(["require", "exports"], function(require, exports) {
           validate.errors = vErrors;
           return errors === 0;
         };
-        var valid = validate(props);
+        var valid = validate({ properties: props });
         if (!valid) {
           throw new Error(JSON.stringify(validate.errors, null, 2));
         }
@@ -161,7 +161,7 @@ define(["require", "exports"], function(require, exports) {
           validate.errors = vErrors;
           return errors === 0;
         };
-        var valid = validate(props);
+        var valid = validate({ properties: props });
         if (!valid) {
           throw new Error(JSON.stringify(validate.errors, null, 2));
         }
@@ -1058,7 +1058,7 @@ define(["require", "exports"], function(require, exports) {
           validate.errors = vErrors;
           return errors === 0;
         };
-        var valid = validate(props);
+        var valid = validate({ properties: props });
         if (!valid) {
           throw new Error(JSON.stringify(validate.errors, null, 2));
         }

--- a/tests/commands/js/__snapshots__/index.js
+++ b/tests/commands/js/__snapshots__/index.js
@@ -88,7 +88,7 @@ export default class Analytics {
         validate.errors = vErrors;
         return errors === 0;
       };
-      var valid = validate(props);
+      var valid = validate({ properties: props });
       if (!valid) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
@@ -158,7 +158,7 @@ export default class Analytics {
         validate.errors = vErrors;
         return errors === 0;
       };
-      var valid = validate(props);
+      var valid = validate({ properties: props });
       if (!valid) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
@@ -1039,7 +1039,7 @@ export default class Analytics {
         validate.errors = vErrors;
         return errors === 0;
       };
-      var valid = validate(props);
+      var valid = validate({ properties: props });
       if (!valid) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }

--- a/tests/commands/js/__snapshots__/index.system.js
+++ b/tests/commands/js/__snapshots__/index.system.js
@@ -99,7 +99,7 @@ System.register([], function(exports_1, context_1) {
               validate.errors = vErrors;
               return errors === 0;
             };
-            var valid = validate(props);
+            var valid = validate({ properties: props });
             if (!valid) {
               throw new Error(JSON.stringify(validate.errors, null, 2));
             }
@@ -173,7 +173,7 @@ System.register([], function(exports_1, context_1) {
               validate.errors = vErrors;
               return errors === 0;
             };
-            var valid = validate(props);
+            var valid = validate({ properties: props });
             if (!valid) {
               throw new Error(JSON.stringify(validate.errors, null, 2));
             }
@@ -1099,7 +1099,7 @@ System.register([], function(exports_1, context_1) {
               validate.errors = vErrors;
               return errors === 0;
             };
-            var valid = validate(props);
+            var valid = validate({ properties: props });
             if (!valid) {
               throw new Error(JSON.stringify(validate.errors, null, 2));
             }

--- a/tests/commands/js/__snapshots__/index.umd.js
+++ b/tests/commands/js/__snapshots__/index.umd.js
@@ -98,7 +98,7 @@
           validate.errors = vErrors;
           return errors === 0;
         };
-        var valid = validate(props);
+        var valid = validate({ properties: props });
         if (!valid) {
           throw new Error(JSON.stringify(validate.errors, null, 2));
         }
@@ -168,7 +168,7 @@
           validate.errors = vErrors;
           return errors === 0;
         };
-        var valid = validate(props);
+        var valid = validate({ properties: props });
         if (!valid) {
           throw new Error(JSON.stringify(validate.errors, null, 2));
         }
@@ -1065,7 +1065,7 @@
           validate.errors = vErrors;
           return errors === 0;
         };
-        var valid = validate(props);
+        var valid = validate({ properties: props });
         if (!valid) {
           throw new Error(JSON.stringify(validate.errors, null, 2));
         }


### PR DESCRIPTION
This fixes an issue where validation wouldn't fire on `gen-js` properties.