### PR TITLE
fix: hide AJV warnings for gen-js

### DIFF
--- a/src/commands/gen-js.ts
+++ b/src/commands/gen-js.ts
@@ -61,7 +61,7 @@ export async function genJS(
   client = Client.js
 ) {
   // Force draft-04 compatibility mode for Ajv (defaults to 06)
-  const ajv = new Ajv({ schemaId: 'id', allErrors: true, sourceCode: true })
+  const ajv = new Ajv({ schemaId: 'auto', allErrors: true, sourceCode: true })
   ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
 
   const fileHeader = `


### PR DESCRIPTION
| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/2907397/48170109-ef2fb900-e2aa-11e8-944e-12df9a9e48cc.png) | ![image](https://user-images.githubusercontent.com/2907397/48170117-ffe02f00-e2aa-11e8-9647-5018ce60073a.png) |

![hp](https://user-images.githubusercontent.com/2907397/48170226-682f1080-e2ab-11e8-81cd-3f50677bfa32.gif)
