### PR TITLE
feat: add flag to disable run-time validation for gen-js

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -1,7 +1,3 @@
-export interface AnalyticsOptions {
-  propertyValidation: boolean;
-}
-
 export type AnalyticsJSCallback = () => void;
 
 /** A dictionary of options. For example, enable or disable specific destinations for the call. */
@@ -39,7 +35,7 @@ export interface ProfileViewed {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any, options?: AnalyticsOptions);
+  constructor(analytics: any);
 
   feedViewed(
     message: FeedViewed,

--- a/examples/gen-js/js/analytics/generated/index.js
+++ b/examples/gen-js/js/analytics/generated/index.js
@@ -11,271 +11,259 @@ export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
    * @param {Analytics} analytics - The analytics.js library to wrap
-   * @param {Object} config - A configuration object to customize runtime behavior
    */
-  constructor(analytics, options = {}) {
-    const { propertyValidation = true } = options;
+  constructor(analytics) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
-    this.analytics = analytics;
-    this.propertyValidation = propertyValidation;
+    this.analytics = analytics || { track: () => null };
   }
   feedViewed(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 !== undefined) {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.profile_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "profile_id" },
-                  message: "should have required property 'profile_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.profile_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.profile_id",
-                    schemaPath:
-                      "#/properties/properties/properties/profile_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.profile_id === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "profile_id" },
+                message: "should have required property 'profile_id'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.profile_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.profile_id",
+                  schemaPath:
+                    "#/properties/properties/properties/profile_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Feed Viewed", props, genOptions(context));
   }
   photoViewed(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 !== undefined) {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.photo_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "photo_id" },
-                  message: "should have required property 'photo_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.photo_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.photo_id",
-                    schemaPath:
-                      "#/properties/properties/properties/photo_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.photo_id === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "photo_id" },
+                message: "should have required property 'photo_id'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.photo_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.photo_id",
+                  schemaPath:
+                    "#/properties/properties/properties/photo_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Photo Viewed", props, genOptions(context));
   }
   profileViewed(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 !== undefined) {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.profile_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "profile_id" },
-                  message: "should have required property 'profile_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.profile_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.profile_id",
-                    schemaPath:
-                      "#/properties/properties/properties/profile_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.profile_id === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "profile_id" },
+                message: "should have required property 'profile_id'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.profile_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.profile_id",
+                  schemaPath:
+                    "#/properties/properties/properties/profile_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Profile Viewed", props, genOptions(context));
   }

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -1,7 +1,3 @@
-export interface AnalyticsOptions {
-  propertyValidation: boolean;
-}
-
 export interface Message {
   type: string;
   context: {
@@ -156,7 +152,7 @@ export interface Product {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any, options?: AnalyticsOptions);
+  constructor(analytics: any);
 
   orderCompleted(
     message: TrackMessage<OrderCompleted>,

--- a/examples/gen-js/node/analytics/generated/index.js
+++ b/examples/gen-js/node/analytics/generated/index.js
@@ -12,566 +12,558 @@ class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
    * @param {Analytics} analytics - The analytics-node library to wrap
-   * @param {Object} config - A configuration object to customize runtime behavior
    */
-  constructor(analytics, options = {}) {
-    const { propertyValidation = true } = options;
+  constructor(analytics) {
     if (!analytics) {
       throw new Error("An instance of analytics-node must be provided");
     }
-    this.analytics = analytics;
-    this.propertyValidation = propertyValidation;
+    this.analytics = analytics || { track: () => null };
   }
   orderCompleted(message, callback) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
-            var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.affiliation !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.affiliation !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.affiliation",
-                    schemaPath:
-                      "#/properties/properties/properties/affiliation/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.checkout_id !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.checkout_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.checkout_id",
-                    schemaPath:
-                      "#/properties/properties/properties/checkout_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.coupon !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.coupon !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.coupon",
-                    schemaPath:
-                      "#/properties/properties/properties/coupon/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.currency !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.currency !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.currency",
-                    schemaPath:
-                      "#/properties/properties/properties/currency/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.discount !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.discount !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.discount",
-                    schemaPath:
-                      "#/properties/properties/properties/discount/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.order_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "order_id" },
-                  message: "should have required property 'order_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.order_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.order_id",
-                    schemaPath:
-                      "#/properties/properties/properties/order_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1.products;
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (Array.isArray(data2)) {
-                  var errs__2 = errors;
-                  var valid2;
-                  for (var i2 = 0; i2 < data2.length; i2++) {
-                    var data3 = data2[i2];
-                    var errs_3 = errors;
-                    if (
-                      data3 &&
-                      typeof data3 === "object" &&
-                      !Array.isArray(data3)
-                    ) {
-                      var errs__3 = errors;
-                      var valid4 = true;
-                      if (data3.brand !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.brand !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].brand",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/brand/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.category !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.category !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].category",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/category/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.coupon !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.coupon !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].coupon",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/coupon/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.image_url !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.image_url !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].image_url",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/image_url/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.name !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.name !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].name",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/name/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      var data4 = data3.position;
-                      if (data4 !== undefined) {
-                        var errs_4 = errors;
-                        if (
-                          typeof data4 !== "number" ||
-                          data4 % 1 ||
-                          data4 !== data4
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].position",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/position/type",
-                            params: { type: "integer" },
-                            message: "should be integer"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.price !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.price !== "number") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].price",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/price/type",
-                            params: { type: "number" },
-                            message: "should be number"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.product_id !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.product_id !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].product_id",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/product_id/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.quantity !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.quantity !== "number") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].quantity",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/quantity/type",
-                            params: { type: "number" },
-                            message: "should be number"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.sku !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.sku !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].sku",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/sku/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.url !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.url !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].url",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/url/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3.variant !== undefined) {
-                        var errs_4 = errors;
-                        if (typeof data3.variant !== "string") {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties.products[" +
-                              i2 +
-                              "].variant",
-                            schemaPath:
-                              "#/properties/properties/properties/products/items/properties/variant/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                    } else {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") + ".properties.products[" + i2 + "]",
-                        schemaPath:
-                          "#/properties/properties/properties/products/items/type",
-                        params: { type: "object" },
-                        message: "should be object"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.products",
-                    schemaPath:
-                      "#/properties/properties/properties/products/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.revenue !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.revenue !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.revenue",
-                    schemaPath:
-                      "#/properties/properties/properties/revenue/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.shipping !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.shipping !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.shipping",
-                    schemaPath:
-                      "#/properties/properties/properties/shipping/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.tax !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.tax !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.tax",
-                    schemaPath: "#/properties/properties/properties/tax/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1.total !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1.total !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.total",
-                    schemaPath: "#/properties/properties/properties/total/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
-              var err = {
-                keyword: "type",
-                dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            }
-            var valid1 = errors === errs_1;
-          }
-        } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
           var err = {
-            keyword: "type",
+            keyword: "required",
             dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
           };
           if (vErrors === null) vErrors = [err];
           else vErrors.push(err);
           errors++;
+        } else {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.affiliation !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.affiliation !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.affiliation",
+                  schemaPath:
+                    "#/properties/properties/properties/affiliation/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.checkout_id !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.checkout_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.checkout_id",
+                  schemaPath:
+                    "#/properties/properties/properties/checkout_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.coupon !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.coupon !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.coupon",
+                  schemaPath: "#/properties/properties/properties/coupon/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.currency !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.currency !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.currency",
+                  schemaPath:
+                    "#/properties/properties/properties/currency/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.discount !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.discount !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.discount",
+                  schemaPath:
+                    "#/properties/properties/properties/discount/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.order_id === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "order_id" },
+                message: "should have required property 'order_id'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.order_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.order_id",
+                  schemaPath:
+                    "#/properties/properties/properties/order_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1.products;
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid2;
+                for (var i2 = 0; i2 < data2.length; i2++) {
+                  var data3 = data2[i2];
+                  var errs_3 = errors;
+                  if (
+                    data3 &&
+                    typeof data3 === "object" &&
+                    !Array.isArray(data3)
+                  ) {
+                    var errs__3 = errors;
+                    var valid4 = true;
+                    if (data3.brand !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.brand !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].brand",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/brand/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.category !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.category !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].category",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/category/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.coupon !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.coupon !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].coupon",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/coupon/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.image_url !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.image_url !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].image_url",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/image_url/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.name !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.name !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].name",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/name/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    var data4 = data3.position;
+                    if (data4 !== undefined) {
+                      var errs_4 = errors;
+                      if (
+                        typeof data4 !== "number" ||
+                        data4 % 1 ||
+                        data4 !== data4
+                      ) {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].position",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/position/type",
+                          params: { type: "integer" },
+                          message: "should be integer"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.price !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.price !== "number") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].price",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/price/type",
+                          params: { type: "number" },
+                          message: "should be number"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.product_id !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.product_id !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].product_id",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/product_id/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.quantity !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.quantity !== "number") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].quantity",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/quantity/type",
+                          params: { type: "number" },
+                          message: "should be number"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.sku !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.sku !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].sku",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/sku/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.url !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.url !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].url",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/url/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3.variant !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3.variant !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties.products[" +
+                            i2 +
+                            "].variant",
+                          schemaPath:
+                            "#/properties/properties/properties/products/items/properties/variant/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                  } else {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") + ".properties.products[" + i2 + "]",
+                      schemaPath:
+                        "#/properties/properties/properties/products/items/type",
+                      params: { type: "object" },
+                      message: "should be object"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.products",
+                  schemaPath:
+                    "#/properties/properties/properties/products/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.revenue !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.revenue !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.revenue",
+                  schemaPath: "#/properties/properties/properties/revenue/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.shipping !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.shipping !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.shipping",
+                  schemaPath:
+                    "#/properties/properties/properties/shipping/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.tax !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.tax !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.tax",
+                  schemaPath: "#/properties/properties/properties/tax/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1.total !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1.total !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.total",
+                  schemaPath: "#/properties/properties/properties/total/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate(message);
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate(message)) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Order Completed"

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -1,7 +1,3 @@
-export interface AnalyticsOptions {
-  propertyValidation: boolean;
-}
-
 export type AnalyticsJSCallback = () => void;
 
 /** A dictionary of options. For example, enable or disable specific destinations for the call. */
@@ -39,7 +35,7 @@ export interface ProfileViewed {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any, options?: AnalyticsOptions);
+  constructor(analytics: any);
 
   feedViewed(
     message: FeedViewed,

--- a/examples/gen-js/ts/analytics/generated/index.js
+++ b/examples/gen-js/ts/analytics/generated/index.js
@@ -11,271 +11,259 @@ export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
    * @param {Analytics} analytics - The analytics.js library to wrap
-   * @param {Object} config - A configuration object to customize runtime behavior
    */
-  constructor(analytics, options = {}) {
-    const { propertyValidation = true } = options;
+  constructor(analytics) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
-    this.analytics = analytics;
-    this.propertyValidation = propertyValidation;
+    this.analytics = analytics || { track: () => null };
   }
   feedViewed(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 !== undefined) {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.profile_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "profile_id" },
-                  message: "should have required property 'profile_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.profile_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.profile_id",
-                    schemaPath:
-                      "#/properties/properties/properties/profile_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.profile_id === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "profile_id" },
+                message: "should have required property 'profile_id'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.profile_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.profile_id",
+                  schemaPath:
+                    "#/properties/properties/properties/profile_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Feed Viewed", props, genOptions(context));
   }
   photoViewed(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 !== undefined) {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.photo_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "photo_id" },
-                  message: "should have required property 'photo_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.photo_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.photo_id",
-                    schemaPath:
-                      "#/properties/properties/properties/photo_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.photo_id === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "photo_id" },
+                message: "should have required property 'photo_id'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.photo_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.photo_id",
+                  schemaPath:
+                    "#/properties/properties/properties/photo_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Photo Viewed", props, genOptions(context));
   }
   profileViewed(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 !== undefined) {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-              if (data1.profile_id === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "profile_id" },
-                  message: "should have required property 'profile_id'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1.profile_id !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties.profile_id",
-                    schemaPath:
-                      "#/properties/properties/properties/profile_id/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-            } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 !== undefined) {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+            if (data1.profile_id === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "profile_id" },
+                message: "should have required property 'profile_id'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1.profile_id !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties.profile_id",
+                  schemaPath:
+                    "#/properties/properties/properties/profile_id/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Profile Viewed", props, genOptions(context));
   }

--- a/src/commands/gen-js/index.ts
+++ b/src/commands/gen-js/index.ts
@@ -26,6 +26,7 @@ interface CompilerParams {
   module?: ModuleKind
   client?: string
   declarations?: string
+  runtimeValidation: boolean
 }
 
 export const builder = {
@@ -57,6 +58,12 @@ export const builder = {
     default: 'none',
     choices: Object.keys(Declarations).filter(k => typeof Declarations[k as any] === 'number'),
     description: 'Type declarations to generate alongside the JS library'
+  },
+  runtimeValidation: {
+    type: 'boolean',
+    default: true,
+    required: false,
+    description: 'Whether to output runtime validation code'
   }
 }
 
@@ -64,7 +71,13 @@ export const handler = getTypedTrackHandler(
   async (params: DefaultParams & CompilerParams, { events }) => {
     const files = []
 
-    const jsLibrary = await genJS(events, params.target, params.module, Client[params.client])
+    const jsLibrary = await genJS(
+      events,
+      params.target,
+      params.module,
+      Client[params.client],
+      params.runtimeValidation
+    )
     files.push(writeFile(`${params.outputPath}/index.js`, jsLibrary))
 
     if (Declarations[params.declarations] === Declarations.ts) {

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -22,7 +22,6 @@ import { isES3IdentifierStart } from 'quicktype-core/dist/language/JavaScriptUni
 import { Client } from '.'
 
 declare interface Options {
-  trackingPlan: string
   client: Client
 }
 
@@ -85,10 +84,6 @@ export interface SegmentOptions {
   integrations: { [key: string]: boolean }
 }`
 
-const topLevels = `export interface AnalyticsOptions {
-  propertyValidation: boolean
-}`
-
 /** Target language for a.js TypeScript Declarations */
 class AJSTSDeclarationsTargetLanguage extends TypeScriptTargetLanguage {
   private client: Client
@@ -113,7 +108,6 @@ class AJSTSDeclarationsTargetLanguage extends TypeScriptTargetLanguage {
         declareUnions: true
       },
       {
-        trackingPlan: 'FooBar',
         client: this.client
       }
     )
@@ -175,9 +169,6 @@ class AJSTSDeclarationsRenderer extends TypeScriptRenderer {
   }
 
   protected emitAnalyticsCallbackTypes() {
-    this.emitLine(topLevels)
-    this.ensureBlankLine()
-
     if (this.ajsOptions.client === Client.js) {
       this.emitLine(ajsTopLevels)
     } else if (this.ajsOptions.client === Client.node) {
@@ -191,7 +182,7 @@ class AJSTSDeclarationsRenderer extends TypeScriptRenderer {
       'based on your Tracking Plan.'
     ])
     this.emitBlock('export default class Analytics', '', () => {
-      this.emitLine('constructor(analytics: any, options?: AnalyticsOptions)')
+      this.emitLine('constructor(analytics: any)')
       this.ensureBlankLine()
 
       this.emitAnalyticsFunctions()

--- a/tests/commands/gen-js/__snapshots__/index.amd.js
+++ b/tests/commands/gen-js/__snapshots__/index.amd.js
@@ -14,82 +14,76 @@ define(["require", "exports"], function(require, exports) {
     /**
      * Instantiate a wrapper around an analytics library instance
      * @param {Analytics} analytics - The analytics.js library to wrap
-     * @param {Object} config - A configuration object to customize runtime behavior
      */
-    constructor(analytics, options = {}) {
-      const { propertyValidation = true } = options;
+    constructor(analytics) {
       if (!analytics) {
         throw new Error("An instance of analytics.js must be provided");
       }
-      this.analytics = analytics;
-      this.propertyValidation = propertyValidation;
+      this.analytics = analytics || { track: () => null };
     }
     terribleEventName3(props, context) {
-      if (this.propertyValidation) {
-        var validate = function(
-          data,
-          dataPath,
-          parentData,
-          parentDataProperty,
-          rootData
-        ) {
-          "use strict";
-          var vErrors = null;
-          var errors = 0;
-          if (data && typeof data === "object" && !Array.isArray(data)) {
-            var errs__0 = errors;
-            var valid1 = true;
-            var data1 = data.properties;
-            if (data1 === undefined) {
-              valid1 = false;
-              var err = {
-                keyword: "required",
-                dataPath: (dataPath || "") + "",
-                schemaPath: "#/required",
-                params: { missingProperty: "properties" },
-                message: "should have required property 'properties'"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            } else {
-              var errs_1 = errors;
-              if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-                var errs__1 = errors;
-                var valid2 = true;
-              } else {
-                var err = {
-                  keyword: "type",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/type",
-                  params: { type: "object" },
-                  message: "should be object"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              }
-              var valid1 = errors === errs_1;
-            }
-          } else {
+      var validate = function(
+        data,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        "use strict";
+        var vErrors = null;
+        var errors = 0;
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          var errs__0 = errors;
+          var valid1 = true;
+          var data1 = data.properties;
+          if (data1 === undefined) {
+            valid1 = false;
             var err = {
-              keyword: "type",
+              keyword: "required",
               dataPath: (dataPath || "") + "",
-              schemaPath: "#/type",
-              params: { type: "object" },
-              message: "should be object"
+              schemaPath: "#/required",
+              params: { missingProperty: "properties" },
+              message: "should have required property 'properties'"
             };
             if (vErrors === null) vErrors = [err];
             else vErrors.push(err);
             errors++;
+          } else {
+            var errs_1 = errors;
+            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+              var errs__1 = errors;
+              var valid2 = true;
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            }
+            var valid1 = errors === errs_1;
           }
-          validate.errors = vErrors;
-          return errors === 0;
-        };
-        var valid = validate({ properties: props });
-        if (!valid) {
-          throw new Error(JSON.stringify(validate.errors, null, 2));
+        } else {
+          var err = {
+            keyword: "type",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/type",
+            params: { type: "object" },
+            message: "should be object"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
         }
+        validate.errors = vErrors;
+        return errors === 0;
+      };
+      if (!validate({ properties: props })) {
+        throw new Error(JSON.stringify(validate.errors, null, 2));
       }
       this.analytics.track(
         "42_--terrible==event++name~!3",
@@ -98,965 +92,943 @@ define(["require", "exports"], function(require, exports) {
       );
     }
     emptyEvent(props, context) {
-      if (this.propertyValidation) {
-        var validate = function(
-          data,
-          dataPath,
-          parentData,
-          parentDataProperty,
-          rootData
-        ) {
-          "use strict";
-          var vErrors = null;
-          var errors = 0;
-          if (data && typeof data === "object" && !Array.isArray(data)) {
-            var errs__0 = errors;
-            var valid1 = true;
-            var data1 = data.properties;
-            if (data1 === undefined) {
-              valid1 = false;
+      var validate = function(
+        data,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        "use strict";
+        var vErrors = null;
+        var errors = 0;
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          var errs__0 = errors;
+          var valid1 = true;
+          var data1 = data.properties;
+          if (data1 === undefined) {
+            valid1 = false;
+            var err = {
+              keyword: "required",
+              dataPath: (dataPath || "") + "",
+              schemaPath: "#/required",
+              params: { missingProperty: "properties" },
+              message: "should have required property 'properties'"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            var errs_1 = errors;
+            if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
               var err = {
-                keyword: "required",
-                dataPath: (dataPath || "") + "",
-                schemaPath: "#/required",
-                params: { missingProperty: "properties" },
-                message: "should have required property 'properties'"
+                keyword: "type",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/type",
+                params: { type: "object" },
+                message: "should be object"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
-            } else {
-              var errs_1 = errors;
-              if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
+            }
+            var valid1 = errors === errs_1;
+          }
+        } else {
+          var err = {
+            keyword: "type",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/type",
+            params: { type: "object" },
+            message: "should be object"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+        }
+        validate.errors = vErrors;
+        return errors === 0;
+      };
+      if (!validate({ properties: props })) {
+        throw new Error(JSON.stringify(validate.errors, null, 2));
+      }
+      this.analytics.track("Empty Event", props, genOptions(context));
+    }
+    exampleEvent(props, context) {
+      var pattern0 = new RegExp("FOO|BAR");
+      var validate = function(
+        data,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        "use strict";
+        var vErrors = null;
+        var errors = 0;
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          var errs__0 = errors;
+          var valid1 = true;
+          var data1 = data.properties;
+          if (data1 === undefined) {
+            valid1 = false;
+            var err = {
+              keyword: "required",
+              dataPath: (dataPath || "") + "",
+              schemaPath: "#/required",
+              params: { missingProperty: "properties" },
+              message: "should have required property 'properties'"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            var errs_1 = errors;
+            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+              if (data1["required any"] === undefined) {
                 var err = {
-                  keyword: "type",
+                  keyword: "required",
                   dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/type",
-                  params: { type: "object" },
-                  message: "should be object"
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required any" },
+                  message: "should have required property 'required any'"
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
                 errors++;
               }
-              var valid1 = errors === errs_1;
-            }
-          } else {
-            var err = {
-              keyword: "type",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/type",
-              params: { type: "object" },
-              message: "should be object"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          }
-          validate.errors = vErrors;
-          return errors === 0;
-        };
-        var valid = validate({ properties: props });
-        if (!valid) {
-          throw new Error(JSON.stringify(validate.errors, null, 2));
-        }
-      }
-      this.analytics.track("Empty Event", props, genOptions(context));
-    }
-    exampleEvent(props, context) {
-      if (this.propertyValidation) {
-        var pattern0 = new RegExp("FOO|BAR");
-        var validate = function(
-          data,
-          dataPath,
-          parentData,
-          parentDataProperty,
-          rootData
-        ) {
-          "use strict";
-          var vErrors = null;
-          var errors = 0;
-          if (data && typeof data === "object" && !Array.isArray(data)) {
-            var errs__0 = errors;
-            var valid1 = true;
-            var data1 = data.properties;
-            if (data1 === undefined) {
-              valid1 = false;
-              var err = {
-                keyword: "required",
-                dataPath: (dataPath || "") + "",
-                schemaPath: "#/required",
-                params: { missingProperty: "properties" },
-                message: "should have required property 'properties'"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            } else {
-              var errs_1 = errors;
-              if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-                if (data1["required any"] === undefined) {
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required any" },
-                    message: "should have required property 'required any'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var errs__1 = errors;
-                var valid2 = true;
-                var data2 = data1["optional array"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (Array.isArray(data2)) {
-                    var errs__2 = errors;
-                    var valid2;
-                    for (var i2 = 0; i2 < data2.length; i2++) {
-                      var data3 = data2[i2];
-                      var errs_3 = errors;
-                      if (
-                        data3 &&
-                        typeof data3 === "object" &&
-                        !Array.isArray(data3)
-                      ) {
-                        var errs__3 = errors;
-                        var valid4 = true;
-                        if (data3["optional sub-property"] !== undefined) {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["optional sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['optional array'][" +
-                                i2 +
-                                "]['optional sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
-                        }
-                        if (data3["required sub-property"] === undefined) {
-                          valid4 = false;
+              var errs__1 = errors;
+              var valid2 = true;
+              var data2 = data1["optional array"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (Array.isArray(data2)) {
+                  var errs__2 = errors;
+                  var valid2;
+                  for (var i2 = 0; i2 < data2.length; i2++) {
+                    var data3 = data2[i2];
+                    var errs_3 = errors;
+                    if (
+                      data3 &&
+                      typeof data3 === "object" &&
+                      !Array.isArray(data3)
+                    ) {
+                      var errs__3 = errors;
+                      var valid4 = true;
+                      if (data3["optional sub-property"] !== undefined) {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["optional sub-property"] !== "string"
+                        ) {
                           var err = {
-                            keyword: "required",
+                            keyword: "type",
                             dataPath:
                               (dataPath || "") +
                               ".properties['optional array'][" +
                               i2 +
-                              "]",
+                              "]['optional sub-property']",
                             schemaPath:
-                              "#/properties/properties/properties/optional%20array/items/required",
-                            params: {
-                              missingProperty: "required sub-property"
-                            },
-                            message:
-                              "should have required property 'required sub-property'"
+                              "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
                           };
                           if (vErrors === null) vErrors = [err];
                           else vErrors.push(err);
                           errors++;
-                        } else {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["required sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['optional array'][" +
-                                i2 +
-                                "]['required sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
                         }
-                      } else {
+                        var valid4 = errors === errs_4;
+                      }
+                      if (data3["required sub-property"] === undefined) {
+                        valid4 = false;
                         var err = {
-                          keyword: "type",
+                          keyword: "required",
                           dataPath:
                             (dataPath || "") +
                             ".properties['optional array'][" +
                             i2 +
                             "]",
                           schemaPath:
-                            "#/properties/properties/properties/optional%20array/items/type",
-                          params: { type: "object" },
-                          message: "should be object"
+                            "#/properties/properties/properties/optional%20array/items/required",
+                          params: { missingProperty: "required sub-property" },
+                          message:
+                            "should have required property 'required sub-property'"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional array']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20array/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional array (empty)"] !== undefined) {
-                  var errs_2 = errors;
-                  if (!Array.isArray(data1["optional array (empty)"])) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional array (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20array%20(empty)/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional boolean"] !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data1["optional boolean"] !== "boolean") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional boolean']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20boolean/type",
-                      params: { type: "boolean" },
-                      message: "should be boolean"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional int"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (
-                    typeof data2 !== "number" ||
-                    data2 % 1 ||
-                    data2 !== data2
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional int']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20int/type",
-                      params: { type: "integer" },
-                      message: "should be integer"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional number"] !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data1["optional number"] !== "number") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional number']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20number/type",
-                      params: { type: "number" },
-                      message: "should be number"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional object"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (
-                    data2 &&
-                    typeof data2 === "object" &&
-                    !Array.isArray(data2)
-                  ) {
-                    var errs__2 = errors;
-                    var valid3 = true;
-                    if (data2["optional sub-property"] !== undefined) {
-                      var errs_3 = errors;
-                      if (typeof data2["optional sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional object']['optional sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                    if (data2["required sub-property"] === undefined) {
-                      valid3 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath:
-                          (dataPath || "") + ".properties['optional object']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20object/required",
-                        params: { missingProperty: "required sub-property" },
-                        message:
-                          "should have required property 'required sub-property'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_3 = errors;
-                      if (typeof data2["required sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional object']['required sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional object']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20object/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional object (empty)"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (
-                    !data2 ||
-                    typeof data2 !== "object" ||
-                    Array.isArray(data2)
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional object (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20object%20(empty)/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional string"] !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data1["optional string"] !== "string") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional string']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20string/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional string regex"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data2 === "string") {
-                    if (!pattern0.test(data2)) {
-                      var err = {
-                        keyword: "pattern",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['optional string regex']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20string%20regex/pattern",
-                        params: { pattern: "FOO|BAR" },
-                        message: 'should match pattern "FOO|BAR"'
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional string regex']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20string%20regex/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required array"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required array" },
-                    message: "should have required property 'required array'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (Array.isArray(data2)) {
-                    var errs__2 = errors;
-                    var valid2;
-                    for (var i2 = 0; i2 < data2.length; i2++) {
-                      var data3 = data2[i2];
-                      var errs_3 = errors;
-                      if (
-                        data3 &&
-                        typeof data3 === "object" &&
-                        !Array.isArray(data3)
-                      ) {
-                        var errs__3 = errors;
-                        var valid4 = true;
-                        if (data3["optional sub-property"] !== undefined) {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["optional sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['required array'][" +
-                                i2 +
-                                "]['optional sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
-                        }
-                        if (data3["required sub-property"] === undefined) {
-                          valid4 = false;
+                      } else {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["required sub-property"] !== "string"
+                        ) {
                           var err = {
-                            keyword: "required",
+                            keyword: "type",
                             dataPath:
                               (dataPath || "") +
-                              ".properties['required array'][" +
+                              ".properties['optional array'][" +
                               i2 +
-                              "]",
+                              "]['required sub-property']",
                             schemaPath:
-                              "#/properties/properties/properties/required%20array/items/required",
-                            params: {
-                              missingProperty: "required sub-property"
-                            },
-                            message:
-                              "should have required property 'required sub-property'"
+                              "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
                           };
                           if (vErrors === null) vErrors = [err];
                           else vErrors.push(err);
                           errors++;
-                        } else {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["required sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['required array'][" +
-                                i2 +
-                                "]['required sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
                         }
-                      } else {
+                        var valid4 = errors === errs_4;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional array'][" +
+                          i2 +
+                          "]",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20array/items/type",
+                        params: { type: "object" },
+                        message: "should be object"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional array']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20array/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional array (empty)"] !== undefined) {
+                var errs_2 = errors;
+                if (!Array.isArray(data1["optional array (empty)"])) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['optional array (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20array%20(empty)/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional boolean"] !== undefined) {
+                var errs_2 = errors;
+                if (typeof data1["optional boolean"] !== "boolean") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional boolean']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20boolean/type",
+                    params: { type: "boolean" },
+                    message: "should be boolean"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional int"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                  var err = {
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties['optional int']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20int/type",
+                    params: { type: "integer" },
+                    message: "should be integer"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional number"] !== undefined) {
+                var errs_2 = errors;
+                if (typeof data1["optional number"] !== "number") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional number']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20number/type",
+                    params: { type: "number" },
+                    message: "should be number"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional object"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (
+                  data2 &&
+                  typeof data2 === "object" &&
+                  !Array.isArray(data2)
+                ) {
+                  var errs__2 = errors;
+                  var valid3 = true;
+                  if (data2["optional sub-property"] !== undefined) {
+                    var errs_3 = errors;
+                    if (typeof data2["optional sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional object']['optional sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                  if (data2["required sub-property"] === undefined) {
+                    valid3 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath:
+                        (dataPath || "") + ".properties['optional object']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20object/required",
+                      params: { missingProperty: "required sub-property" },
+                      message:
+                        "should have required property 'required sub-property'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_3 = errors;
+                    if (typeof data2["required sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional object']['required sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional object']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20object/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional object (empty)"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (
+                  !data2 ||
+                  typeof data2 !== "object" ||
+                  Array.isArray(data2)
+                ) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['optional object (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20object%20(empty)/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional string"] !== undefined) {
+                var errs_2 = errors;
+                if (typeof data1["optional string"] !== "string") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional string']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20string/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional string regex"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (typeof data2 === "string") {
+                  if (!pattern0.test(data2)) {
+                    var err = {
+                      keyword: "pattern",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional string regex']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20string%20regex/pattern",
+                      params: { pattern: "FOO|BAR" },
+                      message: 'should match pattern "FOO|BAR"'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20string%20regex/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required array"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required array" },
+                  message: "should have required property 'required array'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (Array.isArray(data2)) {
+                  var errs__2 = errors;
+                  var valid2;
+                  for (var i2 = 0; i2 < data2.length; i2++) {
+                    var data3 = data2[i2];
+                    var errs_3 = errors;
+                    if (
+                      data3 &&
+                      typeof data3 === "object" &&
+                      !Array.isArray(data3)
+                    ) {
+                      var errs__3 = errors;
+                      var valid4 = true;
+                      if (data3["optional sub-property"] !== undefined) {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["optional sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['required array'][" +
+                              i2 +
+                              "]['optional sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid4 = errors === errs_4;
+                      }
+                      if (data3["required sub-property"] === undefined) {
+                        valid4 = false;
                         var err = {
-                          keyword: "type",
+                          keyword: "required",
                           dataPath:
                             (dataPath || "") +
                             ".properties['required array'][" +
                             i2 +
                             "]",
                           schemaPath:
-                            "#/properties/properties/properties/required%20array/items/type",
-                          params: { type: "object" },
-                          message: "should be object"
+                            "#/properties/properties/properties/required%20array/items/required",
+                          params: { missingProperty: "required sub-property" },
+                          message:
+                            "should have required property 'required sub-property'"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
+                      } else {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["required sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['required array'][" +
+                              i2 +
+                              "]['required sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid4 = errors === errs_4;
                       }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required array']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20array/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required array (empty)"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required array (empty)" },
-                    message:
-                      "should have required property 'required array (empty)'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (!Array.isArray(data1["required array (empty)"])) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['required array (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20array%20(empty)/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required boolean"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required boolean" },
-                    message: "should have required property 'required boolean'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data1["required boolean"] !== "boolean") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required boolean']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20boolean/type",
-                      params: { type: "boolean" },
-                      message: "should be boolean"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required int"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required int" },
-                    message: "should have required property 'required int'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (
-                    typeof data2 !== "number" ||
-                    data2 % 1 ||
-                    data2 !== data2
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required int']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20int/type",
-                      params: { type: "integer" },
-                      message: "should be integer"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required number"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required number" },
-                    message: "should have required property 'required number'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data1["required number"] !== "number") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required number']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20number/type",
-                      params: { type: "number" },
-                      message: "should be number"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required object"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required object" },
-                    message: "should have required property 'required object'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (
-                    data2 &&
-                    typeof data2 === "object" &&
-                    !Array.isArray(data2)
-                  ) {
-                    var errs__2 = errors;
-                    var valid3 = true;
-                    if (data2["optional sub-property"] !== undefined) {
-                      var errs_3 = errors;
-                      if (typeof data2["optional sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required object']['optional sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                    if (data2["required sub-property"] === undefined) {
-                      valid3 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath:
-                          (dataPath || "") + ".properties['required object']",
-                        schemaPath:
-                          "#/properties/properties/properties/required%20object/required",
-                        params: { missingProperty: "required sub-property" },
-                        message:
-                          "should have required property 'required sub-property'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
                     } else {
-                      var errs_3 = errors;
-                      if (typeof data2["required sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required object']['required sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required object']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20object/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required object (empty)"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required object (empty)" },
-                    message:
-                      "should have required property 'required object (empty)'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (
-                    !data2 ||
-                    typeof data2 !== "object" ||
-                    Array.isArray(data2)
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['required object (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20object%20(empty)/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required string"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required string" },
-                    message: "should have required property 'required string'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data1["required string"] !== "string") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required string']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20string/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required string regex"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required string regex" },
-                    message:
-                      "should have required property 'required string regex'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data2 === "string") {
-                    if (!pattern0.test(data2)) {
                       var err = {
-                        keyword: "pattern",
+                        keyword: "type",
                         dataPath:
                           (dataPath || "") +
-                          ".properties['required string regex']",
+                          ".properties['required array'][" +
+                          i2 +
+                          "]",
                         schemaPath:
-                          "#/properties/properties/properties/required%20string%20regex/pattern",
-                        params: { pattern: "FOO|BAR" },
-                        message: 'should match pattern "FOO|BAR"'
+                          "#/properties/properties/properties/required%20array/items/type",
+                        params: { type: "object" },
+                        message: "should be object"
                       };
                       if (vErrors === null) vErrors = [err];
                       else vErrors.push(err);
                       errors++;
                     }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['required string regex']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20string%20regex/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
+                    var valid3 = errors === errs_3;
                   }
-                  var valid2 = errors === errs_2;
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required array']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20array/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
                 }
-              } else {
+                var valid2 = errors === errs_2;
+              }
+              if (data1["required array (empty)"] === undefined) {
+                valid2 = false;
                 var err = {
-                  keyword: "type",
+                  keyword: "required",
                   dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/type",
-                  params: { type: "object" },
-                  message: "should be object"
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required array (empty)" },
+                  message:
+                    "should have required property 'required array (empty)'"
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
                 errors++;
+              } else {
+                var errs_2 = errors;
+                if (!Array.isArray(data1["required array (empty)"])) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['required array (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20array%20(empty)/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
               }
-              var valid1 = errors === errs_1;
+              if (data1["required boolean"] === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required boolean" },
+                  message: "should have required property 'required boolean'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data1["required boolean"] !== "boolean") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required boolean']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20boolean/type",
+                    params: { type: "boolean" },
+                    message: "should be boolean"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required int"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required int" },
+                  message: "should have required property 'required int'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                  var err = {
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties['required int']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20int/type",
+                    params: { type: "integer" },
+                    message: "should be integer"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["required number"] === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required number" },
+                  message: "should have required property 'required number'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data1["required number"] !== "number") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required number']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20number/type",
+                    params: { type: "number" },
+                    message: "should be number"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required object"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required object" },
+                  message: "should have required property 'required object'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (
+                  data2 &&
+                  typeof data2 === "object" &&
+                  !Array.isArray(data2)
+                ) {
+                  var errs__2 = errors;
+                  var valid3 = true;
+                  if (data2["optional sub-property"] !== undefined) {
+                    var errs_3 = errors;
+                    if (typeof data2["optional sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required object']['optional sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                  if (data2["required sub-property"] === undefined) {
+                    valid3 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath:
+                        (dataPath || "") + ".properties['required object']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20object/required",
+                      params: { missingProperty: "required sub-property" },
+                      message:
+                        "should have required property 'required sub-property'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_3 = errors;
+                    if (typeof data2["required sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required object']['required sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required object']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20object/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required object (empty)"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required object (empty)" },
+                  message:
+                    "should have required property 'required object (empty)'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (
+                  !data2 ||
+                  typeof data2 !== "object" ||
+                  Array.isArray(data2)
+                ) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['required object (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20object%20(empty)/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["required string"] === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required string" },
+                  message: "should have required property 'required string'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data1["required string"] !== "string") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required string']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20string/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required string regex"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required string regex" },
+                  message:
+                    "should have required property 'required string regex'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data2 === "string") {
+                  if (!pattern0.test(data2)) {
+                    var err = {
+                      keyword: "pattern",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['required string regex']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20string%20regex/pattern",
+                      params: { pattern: "FOO|BAR" },
+                      message: 'should match pattern "FOO|BAR"'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20string%20regex/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
             }
-          } else {
-            var err = {
-              keyword: "type",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/type",
-              params: { type: "object" },
-              message: "should be object"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
+            var valid1 = errors === errs_1;
           }
-          validate.errors = vErrors;
-          return errors === 0;
-        };
-        var valid = validate({ properties: props });
-        if (!valid) {
-          throw new Error(JSON.stringify(validate.errors, null, 2));
+        } else {
+          var err = {
+            keyword: "type",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/type",
+            params: { type: "object" },
+            message: "should be object"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
         }
+        validate.errors = vErrors;
+        return errors === 0;
+      };
+      if (!validate({ properties: props })) {
+        throw new Error(JSON.stringify(validate.errors, null, 2));
       }
       this.analytics.track("Example Event", props, genOptions(context));
     }

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -1,7 +1,3 @@
-export interface AnalyticsOptions {
-  propertyValidation: boolean;
-}
-
 export type AnalyticsJSCallback = () => void;
 
 /** A dictionary of options. For example, enable or disable specific destinations for the call. */
@@ -158,7 +154,7 @@ export interface RequiredObject {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any, options?: AnalyticsOptions);
+  constructor(analytics: any);
 
   the42TerribleEventName3(
     message: The42_TerribleEventName3,

--- a/tests/commands/gen-js/__snapshots__/index.js
+++ b/tests/commands/gen-js/__snapshots__/index.js
@@ -11,82 +11,76 @@ export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
    * @param {Analytics} analytics - The analytics.js library to wrap
-   * @param {Object} config - A configuration object to customize runtime behavior
    */
-  constructor(analytics, options = {}) {
-    const { propertyValidation = true } = options;
+  constructor(analytics) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
-    this.analytics = analytics;
-    this.propertyValidation = propertyValidation;
+    this.analytics = analytics || { track: () => null };
   }
   terribleEventName3(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
-            var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-            } else {
-              var err = {
-                keyword: "type",
-                dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            }
-            var valid1 = errors === errs_1;
-          }
-        } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
           var err = {
-            keyword: "type",
+            keyword: "required",
             dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
           };
           if (vErrors === null) vErrors = [err];
           else vErrors.push(err);
           errors++;
+        } else {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track(
       "42_--terrible==event++name~!3",
@@ -95,949 +89,904 @@ export default class Analytics {
     );
   }
   emptyEvent(props, context) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
+          var err = {
+            keyword: "required",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+        } else {
+          var errs_1 = errors;
+          if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
             var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
             };
             if (vErrors === null) vErrors = [err];
             else vErrors.push(err);
             errors++;
-          } else {
-            var errs_1 = errors;
-            if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
+          }
+          var valid1 = errors === errs_1;
+        }
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
+      }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
+    }
+    this.analytics.track("Empty Event", props, genOptions(context));
+  }
+  exampleEvent(props, context) {
+    var pattern0 = new RegExp("FOO|BAR");
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
+          var err = {
+            keyword: "required",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+        } else {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            if (data1["required any"] === undefined) {
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required any" },
+                message: "should have required property 'required any'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
             }
-            var valid1 = errors === errs_1;
-          }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
-        }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
-      }
-    }
-    this.analytics.track("Empty Event", props, genOptions(context));
-  }
-  exampleEvent(props, context) {
-    if (this.propertyValidation) {
-      var pattern0 = new RegExp("FOO|BAR");
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
-            var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              if (data1["required any"] === undefined) {
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required any" },
-                  message: "should have required property 'required any'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              }
-              var errs__1 = errors;
-              var valid2 = true;
-              var data2 = data1["optional array"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (Array.isArray(data2)) {
-                  var errs__2 = errors;
-                  var valid2;
-                  for (var i2 = 0; i2 < data2.length; i2++) {
-                    var data3 = data2[i2];
-                    var errs_3 = errors;
-                    if (
-                      data3 &&
-                      typeof data3 === "object" &&
-                      !Array.isArray(data3)
-                    ) {
-                      var errs__3 = errors;
-                      var valid4 = true;
-                      if (data3["optional sub-property"] !== undefined) {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["optional sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['optional array'][" +
-                              i2 +
-                              "]['optional sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3["required sub-property"] === undefined) {
-                        valid4 = false;
+            var errs__1 = errors;
+            var valid2 = true;
+            var data2 = data1["optional array"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid2;
+                for (var i2 = 0; i2 < data2.length; i2++) {
+                  var data3 = data2[i2];
+                  var errs_3 = errors;
+                  if (
+                    data3 &&
+                    typeof data3 === "object" &&
+                    !Array.isArray(data3)
+                  ) {
+                    var errs__3 = errors;
+                    var valid4 = true;
+                    if (data3["optional sub-property"] !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3["optional sub-property"] !== "string") {
                         var err = {
-                          keyword: "required",
+                          keyword: "type",
                           dataPath:
                             (dataPath || "") +
                             ".properties['optional array'][" +
                             i2 +
-                            "]",
+                            "]['optional sub-property']",
                           schemaPath:
-                            "#/properties/properties/properties/optional%20array/items/required",
-                          params: { missingProperty: "required sub-property" },
-                          message:
-                            "should have required property 'required sub-property'"
+                            "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      } else {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["required sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['optional array'][" +
-                              i2 +
-                              "]['required sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
                       }
-                    } else {
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3["required sub-property"] === undefined) {
+                      valid4 = false;
                       var err = {
-                        keyword: "type",
+                        keyword: "required",
                         dataPath:
                           (dataPath || "") +
                           ".properties['optional array'][" +
                           i2 +
                           "]",
                         schemaPath:
-                          "#/properties/properties/properties/optional%20array/items/type",
-                        params: { type: "object" },
-                        message: "should be object"
+                          "#/properties/properties/properties/optional%20array/items/required",
+                        params: { missingProperty: "required sub-property" },
+                        message:
+                          "should have required property 'required sub-property'"
                       };
                       if (vErrors === null) vErrors = [err];
                       else vErrors.push(err);
                       errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional array']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20array/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional array (empty)"] !== undefined) {
-                var errs_2 = errors;
-                if (!Array.isArray(data1["optional array (empty)"])) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['optional array (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20array%20(empty)/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional boolean"] !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1["optional boolean"] !== "boolean") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional boolean']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20boolean/type",
-                    params: { type: "boolean" },
-                    message: "should be boolean"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional int"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties['optional int']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20int/type",
-                    params: { type: "integer" },
-                    message: "should be integer"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional number"] !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1["optional number"] !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional number']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20number/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional object"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (
-                  data2 &&
-                  typeof data2 === "object" &&
-                  !Array.isArray(data2)
-                ) {
-                  var errs__2 = errors;
-                  var valid3 = true;
-                  if (data2["optional sub-property"] !== undefined) {
-                    var errs_3 = errors;
-                    if (typeof data2["optional sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['optional object']['optional sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                  if (data2["required sub-property"] === undefined) {
-                    valid3 = false;
-                    var err = {
-                      keyword: "required",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional object']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20object/required",
-                      params: { missingProperty: "required sub-property" },
-                      message:
-                        "should have required property 'required sub-property'"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  } else {
-                    var errs_3 = errors;
-                    if (typeof data2["required sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['optional object']['required sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional object']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20object/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional object (empty)"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (
-                  !data2 ||
-                  typeof data2 !== "object" ||
-                  Array.isArray(data2)
-                ) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['optional object (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20object%20(empty)/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional string"] !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1["optional string"] !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional string']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20string/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional string regex"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (typeof data2 === "string") {
-                  if (!pattern0.test(data2)) {
-                    var err = {
-                      keyword: "pattern",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional string regex']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20string%20regex/pattern",
-                      params: { pattern: "FOO|BAR" },
-                      message: 'should match pattern "FOO|BAR"'
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional string regex']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20string%20regex/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required array"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required array" },
-                  message: "should have required property 'required array'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (Array.isArray(data2)) {
-                  var errs__2 = errors;
-                  var valid2;
-                  for (var i2 = 0; i2 < data2.length; i2++) {
-                    var data3 = data2[i2];
-                    var errs_3 = errors;
-                    if (
-                      data3 &&
-                      typeof data3 === "object" &&
-                      !Array.isArray(data3)
-                    ) {
-                      var errs__3 = errors;
-                      var valid4 = true;
-                      if (data3["optional sub-property"] !== undefined) {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["optional sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['required array'][" +
-                              i2 +
-                              "]['optional sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3["required sub-property"] === undefined) {
-                        valid4 = false;
+                    } else {
+                      var errs_4 = errors;
+                      if (typeof data3["required sub-property"] !== "string") {
                         var err = {
-                          keyword: "required",
+                          keyword: "type",
                           dataPath:
                             (dataPath || "") +
-                            ".properties['required array'][" +
+                            ".properties['optional array'][" +
                             i2 +
-                            "]",
+                            "]['required sub-property']",
                           schemaPath:
-                            "#/properties/properties/properties/required%20array/items/required",
-                          params: { missingProperty: "required sub-property" },
-                          message:
-                            "should have required property 'required sub-property'"
+                            "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      } else {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["required sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['required array'][" +
-                              i2 +
-                              "]['required sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
                       }
-                    } else {
+                      var valid4 = errors === errs_4;
+                    }
+                  } else {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional array'][" +
+                        i2 +
+                        "]",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20array/items/type",
+                      params: { type: "object" },
+                      message: "should be object"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional array']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20array/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional array (empty)"] !== undefined) {
+              var errs_2 = errors;
+              if (!Array.isArray(data1["optional array (empty)"])) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional array (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20array%20(empty)/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional boolean"] !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1["optional boolean"] !== "boolean") {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional boolean']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20boolean/type",
+                  params: { type: "boolean" },
+                  message: "should be boolean"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional int"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional int']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20int/type",
+                  params: { type: "integer" },
+                  message: "should be integer"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional number"] !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1["optional number"] !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional number']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20number/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional object"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (data2 && typeof data2 === "object" && !Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid3 = true;
+                if (data2["optional sub-property"] !== undefined) {
+                  var errs_3 = errors;
+                  if (typeof data2["optional sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional object']['optional sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+                if (data2["required sub-property"] === undefined) {
+                  valid3 = false;
+                  var err = {
+                    keyword: "required",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional object']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20object/required",
+                    params: { missingProperty: "required sub-property" },
+                    message:
+                      "should have required property 'required sub-property'"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                } else {
+                  var errs_3 = errors;
+                  if (typeof data2["required sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional object']['required sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional object']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20object/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional object (empty)"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (!data2 || typeof data2 !== "object" || Array.isArray(data2)) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional object (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20object%20(empty)/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional string"] !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1["optional string"] !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional string']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20string/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional string regex"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (typeof data2 === "string") {
+                if (!pattern0.test(data2)) {
+                  var err = {
+                    keyword: "pattern",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20string%20regex/pattern",
+                    params: { pattern: "FOO|BAR" },
+                    message: 'should match pattern "FOO|BAR"'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional string regex']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20string%20regex/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required array"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required array" },
+                message: "should have required property 'required array'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid2;
+                for (var i2 = 0; i2 < data2.length; i2++) {
+                  var data3 = data2[i2];
+                  var errs_3 = errors;
+                  if (
+                    data3 &&
+                    typeof data3 === "object" &&
+                    !Array.isArray(data3)
+                  ) {
+                    var errs__3 = errors;
+                    var valid4 = true;
+                    if (data3["optional sub-property"] !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3["optional sub-property"] !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties['required array'][" +
+                            i2 +
+                            "]['optional sub-property']",
+                          schemaPath:
+                            "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3["required sub-property"] === undefined) {
+                      valid4 = false;
                       var err = {
-                        keyword: "type",
+                        keyword: "required",
                         dataPath:
                           (dataPath || "") +
                           ".properties['required array'][" +
                           i2 +
                           "]",
                         schemaPath:
-                          "#/properties/properties/properties/required%20array/items/type",
-                        params: { type: "object" },
-                        message: "should be object"
+                          "#/properties/properties/properties/required%20array/items/required",
+                        params: { missingProperty: "required sub-property" },
+                        message:
+                          "should have required property 'required sub-property'"
                       };
                       if (vErrors === null) vErrors = [err];
                       else vErrors.push(err);
                       errors++;
+                    } else {
+                      var errs_4 = errors;
+                      if (typeof data3["required sub-property"] !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties['required array'][" +
+                            i2 +
+                            "]['required sub-property']",
+                          schemaPath:
+                            "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
                     }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required array']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20array/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required array (empty)"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required array (empty)" },
-                  message:
-                    "should have required property 'required array (empty)'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (!Array.isArray(data1["required array (empty)"])) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['required array (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20array%20(empty)/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required boolean"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required boolean" },
-                  message: "should have required property 'required boolean'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1["required boolean"] !== "boolean") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required boolean']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20boolean/type",
-                    params: { type: "boolean" },
-                    message: "should be boolean"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required int"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required int" },
-                  message: "should have required property 'required int'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties['required int']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20int/type",
-                    params: { type: "integer" },
-                    message: "should be integer"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required number"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required number" },
-                  message: "should have required property 'required number'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1["required number"] !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required number']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20number/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required object"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required object" },
-                  message: "should have required property 'required object'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (
-                  data2 &&
-                  typeof data2 === "object" &&
-                  !Array.isArray(data2)
-                ) {
-                  var errs__2 = errors;
-                  var valid3 = true;
-                  if (data2["optional sub-property"] !== undefined) {
-                    var errs_3 = errors;
-                    if (typeof data2["optional sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['required object']['optional sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                  if (data2["required sub-property"] === undefined) {
-                    valid3 = false;
-                    var err = {
-                      keyword: "required",
-                      dataPath:
-                        (dataPath || "") + ".properties['required object']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20object/required",
-                      params: { missingProperty: "required sub-property" },
-                      message:
-                        "should have required property 'required sub-property'"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
                   } else {
-                    var errs_3 = errors;
-                    if (typeof data2["required sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['required object']['required sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required object']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20object/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required object (empty)"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required object (empty)" },
-                  message:
-                    "should have required property 'required object (empty)'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (
-                  !data2 ||
-                  typeof data2 !== "object" ||
-                  Array.isArray(data2)
-                ) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['required object (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20object%20(empty)/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required string"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required string" },
-                  message: "should have required property 'required string'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1["required string"] !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required string']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20string/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required string regex"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required string regex" },
-                  message:
-                    "should have required property 'required string regex'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data2 === "string") {
-                  if (!pattern0.test(data2)) {
                     var err = {
-                      keyword: "pattern",
+                      keyword: "type",
                       dataPath:
                         (dataPath || "") +
-                        ".properties['required string regex']",
+                        ".properties['required array'][" +
+                        i2 +
+                        "]",
                       schemaPath:
-                        "#/properties/properties/properties/required%20string%20regex/pattern",
-                      params: { pattern: "FOO|BAR" },
-                      message: 'should match pattern "FOO|BAR"'
+                        "#/properties/properties/properties/required%20array/items/type",
+                      params: { type: "object" },
+                      message: "should be object"
                     };
                     if (vErrors === null) vErrors = [err];
                     else vErrors.push(err);
                     errors++;
                   }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required string regex']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20string%20regex/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
+                  var valid3 = errors === errs_3;
                 }
-                var valid2 = errors === errs_2;
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required array']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20array/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
               }
-            } else {
+              var valid2 = errors === errs_2;
+            }
+            if (data1["required array (empty)"] === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required array (empty)" },
+                message:
+                  "should have required property 'required array (empty)'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (!Array.isArray(data1["required array (empty)"])) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required array (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20array%20(empty)/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+            if (data1["required boolean"] === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required boolean" },
+                message: "should have required property 'required boolean'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1["required boolean"] !== "boolean") {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required boolean']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20boolean/type",
+                  params: { type: "boolean" },
+                  message: "should be boolean"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required int"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required int" },
+                message: "should have required property 'required int'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required int']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20int/type",
+                  params: { type: "integer" },
+                  message: "should be integer"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["required number"] === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required number" },
+                message: "should have required property 'required number'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1["required number"] !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required number']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20number/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required object"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required object" },
+                message: "should have required property 'required object'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (data2 && typeof data2 === "object" && !Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid3 = true;
+                if (data2["optional sub-property"] !== undefined) {
+                  var errs_3 = errors;
+                  if (typeof data2["optional sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['required object']['optional sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+                if (data2["required sub-property"] === undefined) {
+                  valid3 = false;
+                  var err = {
+                    keyword: "required",
+                    dataPath:
+                      (dataPath || "") + ".properties['required object']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20object/required",
+                    params: { missingProperty: "required sub-property" },
+                    message:
+                      "should have required property 'required sub-property'"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                } else {
+                  var errs_3 = errors;
+                  if (typeof data2["required sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['required object']['required sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required object']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20object/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required object (empty)"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required object (empty)" },
+                message:
+                  "should have required property 'required object (empty)'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (!data2 || typeof data2 !== "object" || Array.isArray(data2)) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required object (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20object%20(empty)/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["required string"] === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required string" },
+                message: "should have required property 'required string'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1["required string"] !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required string']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20string/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required string regex"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required string regex" },
+                message: "should have required property 'required string regex'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data2 === "string") {
+                if (!pattern0.test(data2)) {
+                  var err = {
+                    keyword: "pattern",
+                    dataPath:
+                      (dataPath || "") + ".properties['required string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20string%20regex/pattern",
+                    params: { pattern: "FOO|BAR" },
+                    message: 'should match pattern "FOO|BAR"'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required string regex']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20string%20regex/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate({ properties: props });
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate({ properties: props })) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Example Event", props, genOptions(context));
   }

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -1,7 +1,3 @@
-export interface AnalyticsOptions {
-  propertyValidation: boolean;
-}
-
 export interface Message {
   type: string;
   context: {
@@ -195,7 +191,7 @@ export interface RequiredObject {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any, options?: AnalyticsOptions);
+  constructor(analytics: any);
 
   the42TerribleEventName3(
     message: TrackMessage<The42_TerribleEventName3>,

--- a/tests/commands/gen-js/__snapshots__/index.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.node.js
@@ -12,82 +12,76 @@ class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
    * @param {Analytics} analytics - The analytics-node library to wrap
-   * @param {Object} config - A configuration object to customize runtime behavior
    */
-  constructor(analytics, options = {}) {
-    const { propertyValidation = true } = options;
+  constructor(analytics) {
     if (!analytics) {
       throw new Error("An instance of analytics-node must be provided");
     }
-    this.analytics = analytics;
-    this.propertyValidation = propertyValidation;
+    this.analytics = analytics || { track: () => null };
   }
   terribleEventName3(message, callback) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
-            var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              var errs__1 = errors;
-              var valid2 = true;
-            } else {
-              var err = {
-                keyword: "type",
-                dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            }
-            var valid1 = errors === errs_1;
-          }
-        } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
           var err = {
-            keyword: "type",
+            keyword: "required",
             dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
           };
           if (vErrors === null) vErrors = [err];
           else vErrors.push(err);
           errors++;
+        } else {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            var errs__1 = errors;
+            var valid2 = true;
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate(message);
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate(message)) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     message = Object.assign({}, message, genOptions(message.context), {
       event: "42_--terrible==event++name~!3"
@@ -95,68 +89,65 @@ class Analytics {
     this.analytics.track(message, callback);
   }
   emptyEvent(message, callback) {
-    if (this.propertyValidation) {
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
-            var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            var errs_1 = errors;
-            if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
-              var err = {
-                keyword: "type",
-                dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            }
-            var valid1 = errors === errs_1;
-          }
-        } else {
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
           var err = {
-            keyword: "type",
+            keyword: "required",
             dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
           };
           if (vErrors === null) vErrors = [err];
           else vErrors.push(err);
           errors++;
+        } else {
+          var errs_1 = errors;
+          if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          }
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate(message);
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate(message)) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Empty Event"
@@ -164,883 +155,841 @@ class Analytics {
     this.analytics.track(message, callback);
   }
   exampleEvent(message, callback) {
-    if (this.propertyValidation) {
-      var pattern0 = new RegExp("FOO|BAR");
-      var validate = function(
-        data,
-        dataPath,
-        parentData,
-        parentDataProperty,
-        rootData
-      ) {
-        "use strict";
-        var vErrors = null;
-        var errors = 0;
-        if (data && typeof data === "object" && !Array.isArray(data)) {
-          var errs__0 = errors;
-          var valid1 = true;
-          var data1 = data.properties;
-          if (data1 === undefined) {
-            valid1 = false;
-            var err = {
-              keyword: "required",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/required",
-              params: { missingProperty: "properties" },
-              message: "should have required property 'properties'"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          } else {
-            var errs_1 = errors;
-            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-              if (data1["required any"] === undefined) {
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required any" },
-                  message: "should have required property 'required any'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              }
-              var errs__1 = errors;
-              var valid2 = true;
-              var data2 = data1["optional array"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (Array.isArray(data2)) {
-                  var errs__2 = errors;
-                  var valid2;
-                  for (var i2 = 0; i2 < data2.length; i2++) {
-                    var data3 = data2[i2];
-                    var errs_3 = errors;
-                    if (
-                      data3 &&
-                      typeof data3 === "object" &&
-                      !Array.isArray(data3)
-                    ) {
-                      var errs__3 = errors;
-                      var valid4 = true;
-                      if (data3["optional sub-property"] !== undefined) {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["optional sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['optional array'][" +
-                              i2 +
-                              "]['optional sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3["required sub-property"] === undefined) {
-                        valid4 = false;
+    var pattern0 = new RegExp("FOO|BAR");
+    var validate = function(
+      data,
+      dataPath,
+      parentData,
+      parentDataProperty,
+      rootData
+    ) {
+      "use strict";
+      var vErrors = null;
+      var errors = 0;
+      if (data && typeof data === "object" && !Array.isArray(data)) {
+        var errs__0 = errors;
+        var valid1 = true;
+        var data1 = data.properties;
+        if (data1 === undefined) {
+          valid1 = false;
+          var err = {
+            keyword: "required",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/required",
+            params: { missingProperty: "properties" },
+            message: "should have required property 'properties'"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+        } else {
+          var errs_1 = errors;
+          if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+            if (data1["required any"] === undefined) {
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required any" },
+                message: "should have required property 'required any'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            }
+            var errs__1 = errors;
+            var valid2 = true;
+            var data2 = data1["optional array"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid2;
+                for (var i2 = 0; i2 < data2.length; i2++) {
+                  var data3 = data2[i2];
+                  var errs_3 = errors;
+                  if (
+                    data3 &&
+                    typeof data3 === "object" &&
+                    !Array.isArray(data3)
+                  ) {
+                    var errs__3 = errors;
+                    var valid4 = true;
+                    if (data3["optional sub-property"] !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3["optional sub-property"] !== "string") {
                         var err = {
-                          keyword: "required",
+                          keyword: "type",
                           dataPath:
                             (dataPath || "") +
                             ".properties['optional array'][" +
                             i2 +
-                            "]",
+                            "]['optional sub-property']",
                           schemaPath:
-                            "#/properties/properties/properties/optional%20array/items/required",
-                          params: { missingProperty: "required sub-property" },
-                          message:
-                            "should have required property 'required sub-property'"
+                            "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      } else {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["required sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['optional array'][" +
-                              i2 +
-                              "]['required sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
                       }
-                    } else {
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3["required sub-property"] === undefined) {
+                      valid4 = false;
                       var err = {
-                        keyword: "type",
+                        keyword: "required",
                         dataPath:
                           (dataPath || "") +
                           ".properties['optional array'][" +
                           i2 +
                           "]",
                         schemaPath:
-                          "#/properties/properties/properties/optional%20array/items/type",
-                        params: { type: "object" },
-                        message: "should be object"
+                          "#/properties/properties/properties/optional%20array/items/required",
+                        params: { missingProperty: "required sub-property" },
+                        message:
+                          "should have required property 'required sub-property'"
                       };
                       if (vErrors === null) vErrors = [err];
                       else vErrors.push(err);
                       errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional array']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20array/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional array (empty)"] !== undefined) {
-                var errs_2 = errors;
-                if (!Array.isArray(data1["optional array (empty)"])) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['optional array (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20array%20(empty)/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional boolean"] !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1["optional boolean"] !== "boolean") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional boolean']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20boolean/type",
-                    params: { type: "boolean" },
-                    message: "should be boolean"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional int"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties['optional int']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20int/type",
-                    params: { type: "integer" },
-                    message: "should be integer"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional number"] !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1["optional number"] !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional number']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20number/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional object"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (
-                  data2 &&
-                  typeof data2 === "object" &&
-                  !Array.isArray(data2)
-                ) {
-                  var errs__2 = errors;
-                  var valid3 = true;
-                  if (data2["optional sub-property"] !== undefined) {
-                    var errs_3 = errors;
-                    if (typeof data2["optional sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['optional object']['optional sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                  if (data2["required sub-property"] === undefined) {
-                    valid3 = false;
-                    var err = {
-                      keyword: "required",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional object']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20object/required",
-                      params: { missingProperty: "required sub-property" },
-                      message:
-                        "should have required property 'required sub-property'"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  } else {
-                    var errs_3 = errors;
-                    if (typeof data2["required sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['optional object']['required sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional object']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20object/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional object (empty)"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (
-                  !data2 ||
-                  typeof data2 !== "object" ||
-                  Array.isArray(data2)
-                ) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['optional object (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20object%20(empty)/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["optional string"] !== undefined) {
-                var errs_2 = errors;
-                if (typeof data1["optional string"] !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional string']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20string/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["optional string regex"];
-              if (data2 !== undefined) {
-                var errs_2 = errors;
-                if (typeof data2 === "string") {
-                  if (!pattern0.test(data2)) {
-                    var err = {
-                      keyword: "pattern",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional string regex']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20string%20regex/pattern",
-                      params: { pattern: "FOO|BAR" },
-                      message: 'should match pattern "FOO|BAR"'
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['optional string regex']",
-                    schemaPath:
-                      "#/properties/properties/properties/optional%20string%20regex/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required array"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required array" },
-                  message: "should have required property 'required array'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (Array.isArray(data2)) {
-                  var errs__2 = errors;
-                  var valid2;
-                  for (var i2 = 0; i2 < data2.length; i2++) {
-                    var data3 = data2[i2];
-                    var errs_3 = errors;
-                    if (
-                      data3 &&
-                      typeof data3 === "object" &&
-                      !Array.isArray(data3)
-                    ) {
-                      var errs__3 = errors;
-                      var valid4 = true;
-                      if (data3["optional sub-property"] !== undefined) {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["optional sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['required array'][" +
-                              i2 +
-                              "]['optional sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
-                      }
-                      if (data3["required sub-property"] === undefined) {
-                        valid4 = false;
+                    } else {
+                      var errs_4 = errors;
+                      if (typeof data3["required sub-property"] !== "string") {
                         var err = {
-                          keyword: "required",
+                          keyword: "type",
                           dataPath:
                             (dataPath || "") +
-                            ".properties['required array'][" +
+                            ".properties['optional array'][" +
                             i2 +
-                            "]",
+                            "]['required sub-property']",
                           schemaPath:
-                            "#/properties/properties/properties/required%20array/items/required",
-                          params: { missingProperty: "required sub-property" },
-                          message:
-                            "should have required property 'required sub-property'"
+                            "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      } else {
-                        var errs_4 = errors;
-                        if (
-                          typeof data3["required sub-property"] !== "string"
-                        ) {
-                          var err = {
-                            keyword: "type",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['required array'][" +
-                              i2 +
-                              "]['required sub-property']",
-                            schemaPath:
-                              "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
-                            params: { type: "string" },
-                            message: "should be string"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                        var valid4 = errors === errs_4;
                       }
-                    } else {
+                      var valid4 = errors === errs_4;
+                    }
+                  } else {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional array'][" +
+                        i2 +
+                        "]",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20array/items/type",
+                      params: { type: "object" },
+                      message: "should be object"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional array']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20array/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional array (empty)"] !== undefined) {
+              var errs_2 = errors;
+              if (!Array.isArray(data1["optional array (empty)"])) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional array (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20array%20(empty)/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional boolean"] !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1["optional boolean"] !== "boolean") {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional boolean']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20boolean/type",
+                  params: { type: "boolean" },
+                  message: "should be boolean"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional int"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional int']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20int/type",
+                  params: { type: "integer" },
+                  message: "should be integer"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional number"] !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1["optional number"] !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional number']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20number/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional object"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (data2 && typeof data2 === "object" && !Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid3 = true;
+                if (data2["optional sub-property"] !== undefined) {
+                  var errs_3 = errors;
+                  if (typeof data2["optional sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional object']['optional sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+                if (data2["required sub-property"] === undefined) {
+                  valid3 = false;
+                  var err = {
+                    keyword: "required",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional object']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20object/required",
+                    params: { missingProperty: "required sub-property" },
+                    message:
+                      "should have required property 'required sub-property'"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                } else {
+                  var errs_3 = errors;
+                  if (typeof data2["required sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional object']['required sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional object']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20object/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional object (empty)"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (!data2 || typeof data2 !== "object" || Array.isArray(data2)) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional object (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20object%20(empty)/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["optional string"] !== undefined) {
+              var errs_2 = errors;
+              if (typeof data1["optional string"] !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['optional string']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20string/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["optional string regex"];
+            if (data2 !== undefined) {
+              var errs_2 = errors;
+              if (typeof data2 === "string") {
+                if (!pattern0.test(data2)) {
+                  var err = {
+                    keyword: "pattern",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20string%20regex/pattern",
+                    params: { pattern: "FOO|BAR" },
+                    message: 'should match pattern "FOO|BAR"'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['optional string regex']",
+                  schemaPath:
+                    "#/properties/properties/properties/optional%20string%20regex/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required array"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required array" },
+                message: "should have required property 'required array'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid2;
+                for (var i2 = 0; i2 < data2.length; i2++) {
+                  var data3 = data2[i2];
+                  var errs_3 = errors;
+                  if (
+                    data3 &&
+                    typeof data3 === "object" &&
+                    !Array.isArray(data3)
+                  ) {
+                    var errs__3 = errors;
+                    var valid4 = true;
+                    if (data3["optional sub-property"] !== undefined) {
+                      var errs_4 = errors;
+                      if (typeof data3["optional sub-property"] !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties['required array'][" +
+                            i2 +
+                            "]['optional sub-property']",
+                          schemaPath:
+                            "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
+                    }
+                    if (data3["required sub-property"] === undefined) {
+                      valid4 = false;
                       var err = {
-                        keyword: "type",
+                        keyword: "required",
                         dataPath:
                           (dataPath || "") +
                           ".properties['required array'][" +
                           i2 +
                           "]",
                         schemaPath:
-                          "#/properties/properties/properties/required%20array/items/type",
-                        params: { type: "object" },
-                        message: "should be object"
+                          "#/properties/properties/properties/required%20array/items/required",
+                        params: { missingProperty: "required sub-property" },
+                        message:
+                          "should have required property 'required sub-property'"
                       };
                       if (vErrors === null) vErrors = [err];
                       else vErrors.push(err);
                       errors++;
+                    } else {
+                      var errs_4 = errors;
+                      if (typeof data3["required sub-property"] !== "string") {
+                        var err = {
+                          keyword: "type",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties['required array'][" +
+                            i2 +
+                            "]['required sub-property']",
+                          schemaPath:
+                            "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
+                          params: { type: "string" },
+                          message: "should be string"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                      var valid4 = errors === errs_4;
                     }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required array']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20array/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required array (empty)"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required array (empty)" },
-                  message:
-                    "should have required property 'required array (empty)'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (!Array.isArray(data1["required array (empty)"])) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['required array (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20array%20(empty)/type",
-                    params: { type: "array" },
-                    message: "should be array"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required boolean"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required boolean" },
-                  message: "should have required property 'required boolean'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1["required boolean"] !== "boolean") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required boolean']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20boolean/type",
-                    params: { type: "boolean" },
-                    message: "should be boolean"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required int"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required int" },
-                  message: "should have required property 'required int'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
-                  var err = {
-                    keyword: "type",
-                    dataPath: (dataPath || "") + ".properties['required int']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20int/type",
-                    params: { type: "integer" },
-                    message: "should be integer"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required number"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required number" },
-                  message: "should have required property 'required number'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1["required number"] !== "number") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required number']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20number/type",
-                    params: { type: "number" },
-                    message: "should be number"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required object"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required object" },
-                  message: "should have required property 'required object'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (
-                  data2 &&
-                  typeof data2 === "object" &&
-                  !Array.isArray(data2)
-                ) {
-                  var errs__2 = errors;
-                  var valid3 = true;
-                  if (data2["optional sub-property"] !== undefined) {
-                    var errs_3 = errors;
-                    if (typeof data2["optional sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['required object']['optional sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                  if (data2["required sub-property"] === undefined) {
-                    valid3 = false;
-                    var err = {
-                      keyword: "required",
-                      dataPath:
-                        (dataPath || "") + ".properties['required object']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20object/required",
-                      params: { missingProperty: "required sub-property" },
-                      message:
-                        "should have required property 'required sub-property'"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
                   } else {
-                    var errs_3 = errors;
-                    if (typeof data2["required sub-property"] !== "string") {
-                      var err = {
-                        keyword: "type",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['required object']['required sub-property']",
-                        schemaPath:
-                          "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
-                        params: { type: "string" },
-                        message: "should be string"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var valid3 = errors === errs_3;
-                  }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required object']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20object/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required object (empty)"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required object (empty)" },
-                  message:
-                    "should have required property 'required object (empty)'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (
-                  !data2 ||
-                  typeof data2 !== "object" ||
-                  Array.isArray(data2)
-                ) {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") +
-                      ".properties['required object (empty)']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20object%20(empty)/type",
-                    params: { type: "object" },
-                    message: "should be object"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              if (data1["required string"] === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required string" },
-                  message: "should have required property 'required string'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data1["required string"] !== "string") {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required string']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20string/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var valid2 = errors === errs_2;
-              }
-              var data2 = data1["required string regex"];
-              if (data2 === undefined) {
-                valid2 = false;
-                var err = {
-                  keyword: "required",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/required",
-                  params: { missingProperty: "required string regex" },
-                  message:
-                    "should have required property 'required string regex'"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              } else {
-                var errs_2 = errors;
-                if (typeof data2 === "string") {
-                  if (!pattern0.test(data2)) {
                     var err = {
-                      keyword: "pattern",
+                      keyword: "type",
                       dataPath:
                         (dataPath || "") +
-                        ".properties['required string regex']",
+                        ".properties['required array'][" +
+                        i2 +
+                        "]",
                       schemaPath:
-                        "#/properties/properties/properties/required%20string%20regex/pattern",
-                      params: { pattern: "FOO|BAR" },
-                      message: 'should match pattern "FOO|BAR"'
+                        "#/properties/properties/properties/required%20array/items/type",
+                      params: { type: "object" },
+                      message: "should be object"
                     };
                     if (vErrors === null) vErrors = [err];
                     else vErrors.push(err);
                     errors++;
                   }
-                } else {
-                  var err = {
-                    keyword: "type",
-                    dataPath:
-                      (dataPath || "") + ".properties['required string regex']",
-                    schemaPath:
-                      "#/properties/properties/properties/required%20string%20regex/type",
-                    params: { type: "string" },
-                    message: "should be string"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
+                  var valid3 = errors === errs_3;
                 }
-                var valid2 = errors === errs_2;
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required array']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20array/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
               }
-            } else {
+              var valid2 = errors === errs_2;
+            }
+            if (data1["required array (empty)"] === undefined) {
+              valid2 = false;
               var err = {
-                keyword: "type",
+                keyword: "required",
                 dataPath: (dataPath || "") + ".properties",
-                schemaPath: "#/properties/properties/type",
-                params: { type: "object" },
-                message: "should be object"
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required array (empty)" },
+                message:
+                  "should have required property 'required array (empty)'"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
+            } else {
+              var errs_2 = errors;
+              if (!Array.isArray(data1["required array (empty)"])) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required array (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20array%20(empty)/type",
+                  params: { type: "array" },
+                  message: "should be array"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
             }
-            var valid1 = errors === errs_1;
+            if (data1["required boolean"] === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required boolean" },
+                message: "should have required property 'required boolean'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1["required boolean"] !== "boolean") {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required boolean']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20boolean/type",
+                  params: { type: "boolean" },
+                  message: "should be boolean"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required int"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required int" },
+                message: "should have required property 'required int'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required int']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20int/type",
+                  params: { type: "integer" },
+                  message: "should be integer"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["required number"] === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required number" },
+                message: "should have required property 'required number'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1["required number"] !== "number") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required number']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20number/type",
+                  params: { type: "number" },
+                  message: "should be number"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required object"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required object" },
+                message: "should have required property 'required object'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (data2 && typeof data2 === "object" && !Array.isArray(data2)) {
+                var errs__2 = errors;
+                var valid3 = true;
+                if (data2["optional sub-property"] !== undefined) {
+                  var errs_3 = errors;
+                  if (typeof data2["optional sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['required object']['optional sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+                if (data2["required sub-property"] === undefined) {
+                  valid3 = false;
+                  var err = {
+                    keyword: "required",
+                    dataPath:
+                      (dataPath || "") + ".properties['required object']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20object/required",
+                    params: { missingProperty: "required sub-property" },
+                    message:
+                      "should have required property 'required sub-property'"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                } else {
+                  var errs_3 = errors;
+                  if (typeof data2["required sub-property"] !== "string") {
+                    var err = {
+                      keyword: "type",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['required object']['required sub-property']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
+                      params: { type: "string" },
+                      message: "should be string"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                  var valid3 = errors === errs_3;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required object']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20object/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required object (empty)"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required object (empty)" },
+                message:
+                  "should have required property 'required object (empty)'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (!data2 || typeof data2 !== "object" || Array.isArray(data2)) {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required object (empty)']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20object%20(empty)/type",
+                  params: { type: "object" },
+                  message: "should be object"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            if (data1["required string"] === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required string" },
+                message: "should have required property 'required string'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data1["required string"] !== "string") {
+                var err = {
+                  keyword: "type",
+                  dataPath: (dataPath || "") + ".properties['required string']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20string/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+            var data2 = data1["required string regex"];
+            if (data2 === undefined) {
+              valid2 = false;
+              var err = {
+                keyword: "required",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/required",
+                params: { missingProperty: "required string regex" },
+                message: "should have required property 'required string regex'"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            } else {
+              var errs_2 = errors;
+              if (typeof data2 === "string") {
+                if (!pattern0.test(data2)) {
+                  var err = {
+                    keyword: "pattern",
+                    dataPath:
+                      (dataPath || "") + ".properties['required string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20string%20regex/pattern",
+                    params: { pattern: "FOO|BAR" },
+                    message: 'should match pattern "FOO|BAR"'
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+              } else {
+                var err = {
+                  keyword: "type",
+                  dataPath:
+                    (dataPath || "") + ".properties['required string regex']",
+                  schemaPath:
+                    "#/properties/properties/properties/required%20string%20regex/type",
+                  params: { type: "string" },
+                  message: "should be string"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              }
+              var valid2 = errors === errs_2;
+            }
+          } else {
+            var err = {
+              keyword: "type",
+              dataPath: (dataPath || "") + ".properties",
+              schemaPath: "#/properties/properties/type",
+              params: { type: "object" },
+              message: "should be object"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
           }
-        } else {
-          var err = {
-            keyword: "type",
-            dataPath: (dataPath || "") + "",
-            schemaPath: "#/type",
-            params: { type: "object" },
-            message: "should be object"
-          };
-          if (vErrors === null) vErrors = [err];
-          else vErrors.push(err);
-          errors++;
+          var valid1 = errors === errs_1;
         }
-        validate.errors = vErrors;
-        return errors === 0;
-      };
-      var valid = validate(message);
-      if (!valid) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+      } else {
+        var err = {
+          keyword: "type",
+          dataPath: (dataPath || "") + "",
+          schemaPath: "#/type",
+          params: { type: "object" },
+          message: "should be object"
+        };
+        if (vErrors === null) vErrors = [err];
+        else vErrors.push(err);
+        errors++;
       }
+      validate.errors = vErrors;
+      return errors === 0;
+    };
+    if (!validate(message)) {
+      throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Example Event"

--- a/tests/commands/gen-js/__snapshots__/index.prod.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.js
@@ -1,0 +1,31 @@
+const genOptions = (context = {}) => ({
+  context: {
+    ...context,
+    typewriter: {
+      name: "gen-js",
+      version: "4.0.0"
+    }
+  }
+});
+export default class Analytics {
+  /**
+   * Instantiate a wrapper around an analytics library instance
+   * @param {Analytics} analytics - The analytics.js library to wrap
+   */
+  constructor(analytics) {
+    this.analytics = analytics || { track: () => null };
+  }
+  terribleEventName3(props, context) {
+    this.analytics.track(
+      "42_--terrible==event++name~!3",
+      props,
+      genOptions(context)
+    );
+  }
+  emptyEvent(props, context) {
+    this.analytics.track("Empty Event", props, genOptions(context));
+  }
+  exampleEvent(props, context) {
+    this.analytics.track("Example Event", props, genOptions(context));
+  }
+}

--- a/tests/commands/gen-js/__snapshots__/index.prod.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.node.js
@@ -1,0 +1,38 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const genOptions = (context = {}) => ({
+  context: Object.assign({}, context, {
+    typewriter: {
+      name: "gen-js",
+      version: "4.0.0"
+    }
+  })
+});
+class Analytics {
+  /**
+   * Instantiate a wrapper around an analytics library instance
+   * @param {Analytics} analytics - The analytics-node library to wrap
+   */
+  constructor(analytics) {
+    this.analytics = analytics || { track: () => null };
+  }
+  terribleEventName3(message, callback) {
+    message = Object.assign({}, message, genOptions(message.context), {
+      event: "42_--terrible==event++name~!3"
+    });
+    this.analytics.track(message, callback);
+  }
+  emptyEvent(message, callback) {
+    message = Object.assign({}, message, genOptions(message.context), {
+      event: "Empty Event"
+    });
+    this.analytics.track(message, callback);
+  }
+  exampleEvent(message, callback) {
+    message = Object.assign({}, message, genOptions(message.context), {
+      event: "Example Event"
+    });
+    this.analytics.track(message, callback);
+  }
+}
+exports.default = Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.system.js
+++ b/tests/commands/gen-js/__snapshots__/index.system.js
@@ -18,86 +18,80 @@ System.register([], function(exports_1, context_1) {
         /**
          * Instantiate a wrapper around an analytics library instance
          * @param {Analytics} analytics - The analytics.js library to wrap
-         * @param {Object} config - A configuration object to customize runtime behavior
          */
-        constructor(analytics, options = {}) {
-          const { propertyValidation = true } = options;
+        constructor(analytics) {
           if (!analytics) {
             throw new Error("An instance of analytics.js must be provided");
           }
-          this.analytics = analytics;
-          this.propertyValidation = propertyValidation;
+          this.analytics = analytics || { track: () => null };
         }
         terribleEventName3(props, context) {
-          if (this.propertyValidation) {
-            var validate = function(
-              data,
-              dataPath,
-              parentData,
-              parentDataProperty,
-              rootData
-            ) {
-              "use strict";
-              var vErrors = null;
-              var errors = 0;
-              if (data && typeof data === "object" && !Array.isArray(data)) {
-                var errs__0 = errors;
-                var valid1 = true;
-                var data1 = data.properties;
-                if (data1 === undefined) {
-                  valid1 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + "",
-                    schemaPath: "#/required",
-                    params: { missingProperty: "properties" },
-                    message: "should have required property 'properties'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_1 = errors;
-                  if (
-                    data1 &&
-                    typeof data1 === "object" &&
-                    !Array.isArray(data1)
-                  ) {
-                    var errs__1 = errors;
-                    var valid2 = true;
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath: (dataPath || "") + ".properties",
-                      schemaPath: "#/properties/properties/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid1 = errors === errs_1;
-                }
-              } else {
+          var validate = function(
+            data,
+            dataPath,
+            parentData,
+            parentDataProperty,
+            rootData
+          ) {
+            "use strict";
+            var vErrors = null;
+            var errors = 0;
+            if (data && typeof data === "object" && !Array.isArray(data)) {
+              var errs__0 = errors;
+              var valid1 = true;
+              var data1 = data.properties;
+              if (data1 === undefined) {
+                valid1 = false;
                 var err = {
-                  keyword: "type",
+                  keyword: "required",
                   dataPath: (dataPath || "") + "",
-                  schemaPath: "#/type",
-                  params: { type: "object" },
-                  message: "should be object"
+                  schemaPath: "#/required",
+                  params: { missingProperty: "properties" },
+                  message: "should have required property 'properties'"
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
                 errors++;
+              } else {
+                var errs_1 = errors;
+                if (
+                  data1 &&
+                  typeof data1 === "object" &&
+                  !Array.isArray(data1)
+                ) {
+                  var errs__1 = errors;
+                  var valid2 = true;
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties",
+                    schemaPath: "#/properties/properties/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid1 = errors === errs_1;
               }
-              validate.errors = vErrors;
-              return errors === 0;
-            };
-            var valid = validate({ properties: props });
-            if (!valid) {
-              throw new Error(JSON.stringify(validate.errors, null, 2));
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + "",
+                schemaPath: "#/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
             }
+            validate.errors = vErrors;
+            return errors === 0;
+          };
+          if (!validate({ properties: props })) {
+            throw new Error(JSON.stringify(validate.errors, null, 2));
           }
           this.analytics.track(
             "42_--terrible==event++name~!3",
@@ -106,998 +100,976 @@ System.register([], function(exports_1, context_1) {
           );
         }
         emptyEvent(props, context) {
-          if (this.propertyValidation) {
-            var validate = function(
-              data,
-              dataPath,
-              parentData,
-              parentDataProperty,
-              rootData
-            ) {
-              "use strict";
-              var vErrors = null;
-              var errors = 0;
-              if (data && typeof data === "object" && !Array.isArray(data)) {
-                var errs__0 = errors;
-                var valid1 = true;
-                var data1 = data.properties;
-                if (data1 === undefined) {
-                  valid1 = false;
+          var validate = function(
+            data,
+            dataPath,
+            parentData,
+            parentDataProperty,
+            rootData
+          ) {
+            "use strict";
+            var vErrors = null;
+            var errors = 0;
+            if (data && typeof data === "object" && !Array.isArray(data)) {
+              var errs__0 = errors;
+              var valid1 = true;
+              var data1 = data.properties;
+              if (data1 === undefined) {
+                valid1 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + "",
+                  schemaPath: "#/required",
+                  params: { missingProperty: "properties" },
+                  message: "should have required property 'properties'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_1 = errors;
+                if (
+                  !data1 ||
+                  typeof data1 !== "object" ||
+                  Array.isArray(data1)
+                ) {
                   var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + "",
-                    schemaPath: "#/required",
-                    params: { missingProperty: "properties" },
-                    message: "should have required property 'properties'"
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties",
+                    schemaPath: "#/properties/properties/type",
+                    params: { type: "object" },
+                    message: "should be object"
                   };
                   if (vErrors === null) vErrors = [err];
                   else vErrors.push(err);
                   errors++;
-                } else {
-                  var errs_1 = errors;
-                  if (
-                    !data1 ||
-                    typeof data1 !== "object" ||
-                    Array.isArray(data1)
-                  ) {
+                }
+                var valid1 = errors === errs_1;
+              }
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + "",
+                schemaPath: "#/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            }
+            validate.errors = vErrors;
+            return errors === 0;
+          };
+          if (!validate({ properties: props })) {
+            throw new Error(JSON.stringify(validate.errors, null, 2));
+          }
+          this.analytics.track("Empty Event", props, genOptions(context));
+        }
+        exampleEvent(props, context) {
+          var pattern0 = new RegExp("FOO|BAR");
+          var validate = function(
+            data,
+            dataPath,
+            parentData,
+            parentDataProperty,
+            rootData
+          ) {
+            "use strict";
+            var vErrors = null;
+            var errors = 0;
+            if (data && typeof data === "object" && !Array.isArray(data)) {
+              var errs__0 = errors;
+              var valid1 = true;
+              var data1 = data.properties;
+              if (data1 === undefined) {
+                valid1 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + "",
+                  schemaPath: "#/required",
+                  params: { missingProperty: "properties" },
+                  message: "should have required property 'properties'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_1 = errors;
+                if (
+                  data1 &&
+                  typeof data1 === "object" &&
+                  !Array.isArray(data1)
+                ) {
+                  if (data1["required any"] === undefined) {
                     var err = {
-                      keyword: "type",
+                      keyword: "required",
                       dataPath: (dataPath || "") + ".properties",
-                      schemaPath: "#/properties/properties/type",
-                      params: { type: "object" },
-                      message: "should be object"
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required any" },
+                      message: "should have required property 'required any'"
                     };
                     if (vErrors === null) vErrors = [err];
                     else vErrors.push(err);
                     errors++;
                   }
-                  var valid1 = errors === errs_1;
-                }
-              } else {
-                var err = {
-                  keyword: "type",
-                  dataPath: (dataPath || "") + "",
-                  schemaPath: "#/type",
-                  params: { type: "object" },
-                  message: "should be object"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              }
-              validate.errors = vErrors;
-              return errors === 0;
-            };
-            var valid = validate({ properties: props });
-            if (!valid) {
-              throw new Error(JSON.stringify(validate.errors, null, 2));
-            }
-          }
-          this.analytics.track("Empty Event", props, genOptions(context));
-        }
-        exampleEvent(props, context) {
-          if (this.propertyValidation) {
-            var pattern0 = new RegExp("FOO|BAR");
-            var validate = function(
-              data,
-              dataPath,
-              parentData,
-              parentDataProperty,
-              rootData
-            ) {
-              "use strict";
-              var vErrors = null;
-              var errors = 0;
-              if (data && typeof data === "object" && !Array.isArray(data)) {
-                var errs__0 = errors;
-                var valid1 = true;
-                var data1 = data.properties;
-                if (data1 === undefined) {
-                  valid1 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + "",
-                    schemaPath: "#/required",
-                    params: { missingProperty: "properties" },
-                    message: "should have required property 'properties'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_1 = errors;
-                  if (
-                    data1 &&
-                    typeof data1 === "object" &&
-                    !Array.isArray(data1)
-                  ) {
-                    if (data1["required any"] === undefined) {
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required any" },
-                        message: "should have required property 'required any'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                    var errs__1 = errors;
-                    var valid2 = true;
-                    var data2 = data1["optional array"];
-                    if (data2 !== undefined) {
-                      var errs_2 = errors;
-                      if (Array.isArray(data2)) {
-                        var errs__2 = errors;
-                        var valid2;
-                        for (var i2 = 0; i2 < data2.length; i2++) {
-                          var data3 = data2[i2];
-                          var errs_3 = errors;
-                          if (
-                            data3 &&
-                            typeof data3 === "object" &&
-                            !Array.isArray(data3)
-                          ) {
-                            var errs__3 = errors;
-                            var valid4 = true;
-                            if (data3["optional sub-property"] !== undefined) {
-                              var errs_4 = errors;
-                              if (
-                                typeof data3["optional sub-property"] !==
-                                "string"
-                              ) {
-                                var err = {
-                                  keyword: "type",
-                                  dataPath:
-                                    (dataPath || "") +
-                                    ".properties['optional array'][" +
-                                    i2 +
-                                    "]['optional sub-property']",
-                                  schemaPath:
-                                    "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
-                                  params: { type: "string" },
-                                  message: "should be string"
-                                };
-                                if (vErrors === null) vErrors = [err];
-                                else vErrors.push(err);
-                                errors++;
-                              }
-                              var valid4 = errors === errs_4;
-                            }
-                            if (data3["required sub-property"] === undefined) {
-                              valid4 = false;
+                  var errs__1 = errors;
+                  var valid2 = true;
+                  var data2 = data1["optional array"];
+                  if (data2 !== undefined) {
+                    var errs_2 = errors;
+                    if (Array.isArray(data2)) {
+                      var errs__2 = errors;
+                      var valid2;
+                      for (var i2 = 0; i2 < data2.length; i2++) {
+                        var data3 = data2[i2];
+                        var errs_3 = errors;
+                        if (
+                          data3 &&
+                          typeof data3 === "object" &&
+                          !Array.isArray(data3)
+                        ) {
+                          var errs__3 = errors;
+                          var valid4 = true;
+                          if (data3["optional sub-property"] !== undefined) {
+                            var errs_4 = errors;
+                            if (
+                              typeof data3["optional sub-property"] !== "string"
+                            ) {
                               var err = {
-                                keyword: "required",
+                                keyword: "type",
                                 dataPath:
                                   (dataPath || "") +
                                   ".properties['optional array'][" +
                                   i2 +
-                                  "]",
+                                  "]['optional sub-property']",
                                 schemaPath:
-                                  "#/properties/properties/properties/optional%20array/items/required",
-                                params: {
-                                  missingProperty: "required sub-property"
-                                },
-                                message:
-                                  "should have required property 'required sub-property'"
+                                  "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
+                                params: { type: "string" },
+                                message: "should be string"
                               };
                               if (vErrors === null) vErrors = [err];
                               else vErrors.push(err);
                               errors++;
-                            } else {
-                              var errs_4 = errors;
-                              if (
-                                typeof data3["required sub-property"] !==
-                                "string"
-                              ) {
-                                var err = {
-                                  keyword: "type",
-                                  dataPath:
-                                    (dataPath || "") +
-                                    ".properties['optional array'][" +
-                                    i2 +
-                                    "]['required sub-property']",
-                                  schemaPath:
-                                    "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
-                                  params: { type: "string" },
-                                  message: "should be string"
-                                };
-                                if (vErrors === null) vErrors = [err];
-                                else vErrors.push(err);
-                                errors++;
-                              }
-                              var valid4 = errors === errs_4;
                             }
-                          } else {
+                            var valid4 = errors === errs_4;
+                          }
+                          if (data3["required sub-property"] === undefined) {
+                            valid4 = false;
                             var err = {
-                              keyword: "type",
+                              keyword: "required",
                               dataPath:
                                 (dataPath || "") +
                                 ".properties['optional array'][" +
                                 i2 +
                                 "]",
                               schemaPath:
-                                "#/properties/properties/properties/optional%20array/items/type",
-                              params: { type: "object" },
-                              message: "should be object"
+                                "#/properties/properties/properties/optional%20array/items/required",
+                              params: {
+                                missingProperty: "required sub-property"
+                              },
+                              message:
+                                "should have required property 'required sub-property'"
                             };
                             if (vErrors === null) vErrors = [err];
                             else vErrors.push(err);
                             errors++;
-                          }
-                          var valid3 = errors === errs_3;
-                        }
-                      } else {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['optional array']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20array/type",
-                          params: { type: "array" },
-                          message: "should be array"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["optional array (empty)"] !== undefined) {
-                      var errs_2 = errors;
-                      if (!Array.isArray(data1["optional array (empty)"])) {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional array (empty)']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20array%20(empty)/type",
-                          params: { type: "array" },
-                          message: "should be array"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["optional boolean"] !== undefined) {
-                      var errs_2 = errors;
-                      if (typeof data1["optional boolean"] !== "boolean") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional boolean']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20boolean/type",
-                          params: { type: "boolean" },
-                          message: "should be boolean"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["optional int"];
-                    if (data2 !== undefined) {
-                      var errs_2 = errors;
-                      if (
-                        typeof data2 !== "number" ||
-                        data2 % 1 ||
-                        data2 !== data2
-                      ) {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['optional int']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20int/type",
-                          params: { type: "integer" },
-                          message: "should be integer"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["optional number"] !== undefined) {
-                      var errs_2 = errors;
-                      if (typeof data1["optional number"] !== "number") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['optional number']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20number/type",
-                          params: { type: "number" },
-                          message: "should be number"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["optional object"];
-                    if (data2 !== undefined) {
-                      var errs_2 = errors;
-                      if (
-                        data2 &&
-                        typeof data2 === "object" &&
-                        !Array.isArray(data2)
-                      ) {
-                        var errs__2 = errors;
-                        var valid3 = true;
-                        if (data2["optional sub-property"] !== undefined) {
-                          var errs_3 = errors;
-                          if (
-                            typeof data2["optional sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['optional object']['optional sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid3 = errors === errs_3;
-                        }
-                        if (data2["required sub-property"] === undefined) {
-                          valid3 = false;
-                          var err = {
-                            keyword: "required",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['optional object']",
-                            schemaPath:
-                              "#/properties/properties/properties/optional%20object/required",
-                            params: {
-                              missingProperty: "required sub-property"
-                            },
-                            message:
-                              "should have required property 'required sub-property'"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        } else {
-                          var errs_3 = errors;
-                          if (
-                            typeof data2["required sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['optional object']['required sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid3 = errors === errs_3;
-                        }
-                      } else {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['optional object']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20object/type",
-                          params: { type: "object" },
-                          message: "should be object"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["optional object (empty)"];
-                    if (data2 !== undefined) {
-                      var errs_2 = errors;
-                      if (
-                        !data2 ||
-                        typeof data2 !== "object" ||
-                        Array.isArray(data2)
-                      ) {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional object (empty)']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20object%20(empty)/type",
-                          params: { type: "object" },
-                          message: "should be object"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["optional string"] !== undefined) {
-                      var errs_2 = errors;
-                      if (typeof data1["optional string"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['optional string']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20string/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["optional string regex"];
-                    if (data2 !== undefined) {
-                      var errs_2 = errors;
-                      if (typeof data2 === "string") {
-                        if (!pattern0.test(data2)) {
-                          var err = {
-                            keyword: "pattern",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['optional string regex']",
-                            schemaPath:
-                              "#/properties/properties/properties/optional%20string%20regex/pattern",
-                            params: { pattern: "FOO|BAR" },
-                            message: 'should match pattern "FOO|BAR"'
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
-                        }
-                      } else {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional string regex']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20string%20regex/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["required array"];
-                    if (data2 === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required array" },
-                        message:
-                          "should have required property 'required array'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (Array.isArray(data2)) {
-                        var errs__2 = errors;
-                        var valid2;
-                        for (var i2 = 0; i2 < data2.length; i2++) {
-                          var data3 = data2[i2];
-                          var errs_3 = errors;
-                          if (
-                            data3 &&
-                            typeof data3 === "object" &&
-                            !Array.isArray(data3)
-                          ) {
-                            var errs__3 = errors;
-                            var valid4 = true;
-                            if (data3["optional sub-property"] !== undefined) {
-                              var errs_4 = errors;
-                              if (
-                                typeof data3["optional sub-property"] !==
-                                "string"
-                              ) {
-                                var err = {
-                                  keyword: "type",
-                                  dataPath:
-                                    (dataPath || "") +
-                                    ".properties['required array'][" +
-                                    i2 +
-                                    "]['optional sub-property']",
-                                  schemaPath:
-                                    "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
-                                  params: { type: "string" },
-                                  message: "should be string"
-                                };
-                                if (vErrors === null) vErrors = [err];
-                                else vErrors.push(err);
-                                errors++;
-                              }
-                              var valid4 = errors === errs_4;
-                            }
-                            if (data3["required sub-property"] === undefined) {
-                              valid4 = false;
+                          } else {
+                            var errs_4 = errors;
+                            if (
+                              typeof data3["required sub-property"] !== "string"
+                            ) {
                               var err = {
-                                keyword: "required",
+                                keyword: "type",
                                 dataPath:
                                   (dataPath || "") +
-                                  ".properties['required array'][" +
+                                  ".properties['optional array'][" +
                                   i2 +
-                                  "]",
+                                  "]['required sub-property']",
                                 schemaPath:
-                                  "#/properties/properties/properties/required%20array/items/required",
-                                params: {
-                                  missingProperty: "required sub-property"
-                                },
-                                message:
-                                  "should have required property 'required sub-property'"
+                                  "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
+                                params: { type: "string" },
+                                message: "should be string"
                               };
                               if (vErrors === null) vErrors = [err];
                               else vErrors.push(err);
                               errors++;
-                            } else {
-                              var errs_4 = errors;
-                              if (
-                                typeof data3["required sub-property"] !==
-                                "string"
-                              ) {
-                                var err = {
-                                  keyword: "type",
-                                  dataPath:
-                                    (dataPath || "") +
-                                    ".properties['required array'][" +
-                                    i2 +
-                                    "]['required sub-property']",
-                                  schemaPath:
-                                    "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
-                                  params: { type: "string" },
-                                  message: "should be string"
-                                };
-                                if (vErrors === null) vErrors = [err];
-                                else vErrors.push(err);
-                                errors++;
-                              }
-                              var valid4 = errors === errs_4;
                             }
-                          } else {
+                            var valid4 = errors === errs_4;
+                          }
+                        } else {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['optional array'][" +
+                              i2 +
+                              "]",
+                            schemaPath:
+                              "#/properties/properties/properties/optional%20array/items/type",
+                            params: { type: "object" },
+                            message: "should be object"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid3 = errors === errs_3;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['optional array']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20array/type",
+                        params: { type: "array" },
+                        message: "should be array"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["optional array (empty)"] !== undefined) {
+                    var errs_2 = errors;
+                    if (!Array.isArray(data1["optional array (empty)"])) {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional array (empty)']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20array%20(empty)/type",
+                        params: { type: "array" },
+                        message: "should be array"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["optional boolean"] !== undefined) {
+                    var errs_2 = errors;
+                    if (typeof data1["optional boolean"] !== "boolean") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['optional boolean']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20boolean/type",
+                        params: { type: "boolean" },
+                        message: "should be boolean"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["optional int"];
+                  if (data2 !== undefined) {
+                    var errs_2 = errors;
+                    if (
+                      typeof data2 !== "number" ||
+                      data2 % 1 ||
+                      data2 !== data2
+                    ) {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['optional int']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20int/type",
+                        params: { type: "integer" },
+                        message: "should be integer"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["optional number"] !== undefined) {
+                    var errs_2 = errors;
+                    if (typeof data1["optional number"] !== "number") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['optional number']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20number/type",
+                        params: { type: "number" },
+                        message: "should be number"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["optional object"];
+                  if (data2 !== undefined) {
+                    var errs_2 = errors;
+                    if (
+                      data2 &&
+                      typeof data2 === "object" &&
+                      !Array.isArray(data2)
+                    ) {
+                      var errs__2 = errors;
+                      var valid3 = true;
+                      if (data2["optional sub-property"] !== undefined) {
+                        var errs_3 = errors;
+                        if (
+                          typeof data2["optional sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['optional object']['optional sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid3 = errors === errs_3;
+                      }
+                      if (data2["required sub-property"] === undefined) {
+                        valid3 = false;
+                        var err = {
+                          keyword: "required",
+                          dataPath:
+                            (dataPath || "") + ".properties['optional object']",
+                          schemaPath:
+                            "#/properties/properties/properties/optional%20object/required",
+                          params: { missingProperty: "required sub-property" },
+                          message:
+                            "should have required property 'required sub-property'"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      } else {
+                        var errs_3 = errors;
+                        if (
+                          typeof data2["required sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['optional object']['required sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid3 = errors === errs_3;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['optional object']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20object/type",
+                        params: { type: "object" },
+                        message: "should be object"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["optional object (empty)"];
+                  if (data2 !== undefined) {
+                    var errs_2 = errors;
+                    if (
+                      !data2 ||
+                      typeof data2 !== "object" ||
+                      Array.isArray(data2)
+                    ) {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional object (empty)']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20object%20(empty)/type",
+                        params: { type: "object" },
+                        message: "should be object"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["optional string"] !== undefined) {
+                    var errs_2 = errors;
+                    if (typeof data1["optional string"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['optional string']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20string/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["optional string regex"];
+                  if (data2 !== undefined) {
+                    var errs_2 = errors;
+                    if (typeof data2 === "string") {
+                      if (!pattern0.test(data2)) {
+                        var err = {
+                          keyword: "pattern",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties['optional string regex']",
+                          schemaPath:
+                            "#/properties/properties/properties/optional%20string%20regex/pattern",
+                          params: { pattern: "FOO|BAR" },
+                          message: 'should match pattern "FOO|BAR"'
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional string regex']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20string%20regex/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["required array"];
+                  if (data2 === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required array" },
+                      message: "should have required property 'required array'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (Array.isArray(data2)) {
+                      var errs__2 = errors;
+                      var valid2;
+                      for (var i2 = 0; i2 < data2.length; i2++) {
+                        var data3 = data2[i2];
+                        var errs_3 = errors;
+                        if (
+                          data3 &&
+                          typeof data3 === "object" &&
+                          !Array.isArray(data3)
+                        ) {
+                          var errs__3 = errors;
+                          var valid4 = true;
+                          if (data3["optional sub-property"] !== undefined) {
+                            var errs_4 = errors;
+                            if (
+                              typeof data3["optional sub-property"] !== "string"
+                            ) {
+                              var err = {
+                                keyword: "type",
+                                dataPath:
+                                  (dataPath || "") +
+                                  ".properties['required array'][" +
+                                  i2 +
+                                  "]['optional sub-property']",
+                                schemaPath:
+                                  "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
+                                params: { type: "string" },
+                                message: "should be string"
+                              };
+                              if (vErrors === null) vErrors = [err];
+                              else vErrors.push(err);
+                              errors++;
+                            }
+                            var valid4 = errors === errs_4;
+                          }
+                          if (data3["required sub-property"] === undefined) {
+                            valid4 = false;
                             var err = {
-                              keyword: "type",
+                              keyword: "required",
                               dataPath:
                                 (dataPath || "") +
                                 ".properties['required array'][" +
                                 i2 +
                                 "]",
                               schemaPath:
-                                "#/properties/properties/properties/required%20array/items/type",
-                              params: { type: "object" },
-                              message: "should be object"
+                                "#/properties/properties/properties/required%20array/items/required",
+                              params: {
+                                missingProperty: "required sub-property"
+                              },
+                              message:
+                                "should have required property 'required sub-property'"
                             };
                             if (vErrors === null) vErrors = [err];
                             else vErrors.push(err);
                             errors++;
+                          } else {
+                            var errs_4 = errors;
+                            if (
+                              typeof data3["required sub-property"] !== "string"
+                            ) {
+                              var err = {
+                                keyword: "type",
+                                dataPath:
+                                  (dataPath || "") +
+                                  ".properties['required array'][" +
+                                  i2 +
+                                  "]['required sub-property']",
+                                schemaPath:
+                                  "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
+                                params: { type: "string" },
+                                message: "should be string"
+                              };
+                              if (vErrors === null) vErrors = [err];
+                              else vErrors.push(err);
+                              errors++;
+                            }
+                            var valid4 = errors === errs_4;
                           }
-                          var valid3 = errors === errs_3;
-                        }
-                      } else {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['required array']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20array/type",
-                          params: { type: "array" },
-                          message: "should be array"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["required array (empty)"] === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required array (empty)" },
-                        message:
-                          "should have required property 'required array (empty)'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (!Array.isArray(data1["required array (empty)"])) {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required array (empty)']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20array%20(empty)/type",
-                          params: { type: "array" },
-                          message: "should be array"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["required boolean"] === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required boolean" },
-                        message:
-                          "should have required property 'required boolean'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (typeof data1["required boolean"] !== "boolean") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required boolean']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20boolean/type",
-                          params: { type: "boolean" },
-                          message: "should be boolean"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["required int"];
-                    if (data2 === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required int" },
-                        message: "should have required property 'required int'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (
-                        typeof data2 !== "number" ||
-                        data2 % 1 ||
-                        data2 !== data2
-                      ) {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['required int']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20int/type",
-                          params: { type: "integer" },
-                          message: "should be integer"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["required number"] === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required number" },
-                        message:
-                          "should have required property 'required number'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (typeof data1["required number"] !== "number") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['required number']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20number/type",
-                          params: { type: "number" },
-                          message: "should be number"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["required object"];
-                    if (data2 === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required object" },
-                        message:
-                          "should have required property 'required object'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (
-                        data2 &&
-                        typeof data2 === "object" &&
-                        !Array.isArray(data2)
-                      ) {
-                        var errs__2 = errors;
-                        var valid3 = true;
-                        if (data2["optional sub-property"] !== undefined) {
-                          var errs_3 = errors;
-                          if (
-                            typeof data2["optional sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['required object']['optional sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid3 = errors === errs_3;
-                        }
-                        if (data2["required sub-property"] === undefined) {
-                          valid3 = false;
-                          var err = {
-                            keyword: "required",
-                            dataPath:
-                              (dataPath || "") +
-                              ".properties['required object']",
-                            schemaPath:
-                              "#/properties/properties/properties/required%20object/required",
-                            params: {
-                              missingProperty: "required sub-property"
-                            },
-                            message:
-                              "should have required property 'required sub-property'"
-                          };
-                          if (vErrors === null) vErrors = [err];
-                          else vErrors.push(err);
-                          errors++;
                         } else {
-                          var errs_3 = errors;
-                          if (
-                            typeof data2["required sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['required object']['required sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid3 = errors === errs_3;
-                        }
-                      } else {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['required object']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20object/type",
-                          params: { type: "object" },
-                          message: "should be object"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["required object (empty)"];
-                    if (data2 === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required object (empty)" },
-                        message:
-                          "should have required property 'required object (empty)'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (
-                        !data2 ||
-                        typeof data2 !== "object" ||
-                        Array.isArray(data2)
-                      ) {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required object (empty)']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20object%20(empty)/type",
-                          params: { type: "object" },
-                          message: "should be object"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    if (data1["required string"] === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required string" },
-                        message:
-                          "should have required property 'required string'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (typeof data1["required string"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") + ".properties['required string']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20string/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid2 = errors === errs_2;
-                    }
-                    var data2 = data1["required string regex"];
-                    if (data2 === undefined) {
-                      valid2 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath: (dataPath || "") + ".properties",
-                        schemaPath: "#/properties/properties/required",
-                        params: { missingProperty: "required string regex" },
-                        message:
-                          "should have required property 'required string regex'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_2 = errors;
-                      if (typeof data2 === "string") {
-                        if (!pattern0.test(data2)) {
                           var err = {
-                            keyword: "pattern",
+                            keyword: "type",
                             dataPath:
                               (dataPath || "") +
-                              ".properties['required string regex']",
+                              ".properties['required array'][" +
+                              i2 +
+                              "]",
                             schemaPath:
-                              "#/properties/properties/properties/required%20string%20regex/pattern",
-                            params: { pattern: "FOO|BAR" },
-                            message: 'should match pattern "FOO|BAR"'
+                              "#/properties/properties/properties/required%20array/items/type",
+                            params: { type: "object" },
+                            message: "should be object"
                           };
                           if (vErrors === null) vErrors = [err];
                           else vErrors.push(err);
                           errors++;
                         }
-                      } else {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required string regex']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20string%20regex/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
+                        var valid3 = errors === errs_3;
                       }
-                      var valid2 = errors === errs_2;
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['required array']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20array/type",
+                        params: { type: "array" },
+                        message: "should be array"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
                     }
-                  } else {
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["required array (empty)"] === undefined) {
+                    valid2 = false;
                     var err = {
-                      keyword: "type",
+                      keyword: "required",
                       dataPath: (dataPath || "") + ".properties",
-                      schemaPath: "#/properties/properties/type",
-                      params: { type: "object" },
-                      message: "should be object"
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required array (empty)" },
+                      message:
+                        "should have required property 'required array (empty)'"
                     };
                     if (vErrors === null) vErrors = [err];
                     else vErrors.push(err);
                     errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (!Array.isArray(data1["required array (empty)"])) {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required array (empty)']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20array%20(empty)/type",
+                        params: { type: "array" },
+                        message: "should be array"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
                   }
-                  var valid1 = errors === errs_1;
+                  if (data1["required boolean"] === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required boolean" },
+                      message:
+                        "should have required property 'required boolean'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (typeof data1["required boolean"] !== "boolean") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['required boolean']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20boolean/type",
+                        params: { type: "boolean" },
+                        message: "should be boolean"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["required int"];
+                  if (data2 === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required int" },
+                      message: "should have required property 'required int'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (
+                      typeof data2 !== "number" ||
+                      data2 % 1 ||
+                      data2 !== data2
+                    ) {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['required int']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20int/type",
+                        params: { type: "integer" },
+                        message: "should be integer"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["required number"] === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required number" },
+                      message: "should have required property 'required number'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (typeof data1["required number"] !== "number") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['required number']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20number/type",
+                        params: { type: "number" },
+                        message: "should be number"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["required object"];
+                  if (data2 === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required object" },
+                      message: "should have required property 'required object'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (
+                      data2 &&
+                      typeof data2 === "object" &&
+                      !Array.isArray(data2)
+                    ) {
+                      var errs__2 = errors;
+                      var valid3 = true;
+                      if (data2["optional sub-property"] !== undefined) {
+                        var errs_3 = errors;
+                        if (
+                          typeof data2["optional sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['required object']['optional sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid3 = errors === errs_3;
+                      }
+                      if (data2["required sub-property"] === undefined) {
+                        valid3 = false;
+                        var err = {
+                          keyword: "required",
+                          dataPath:
+                            (dataPath || "") + ".properties['required object']",
+                          schemaPath:
+                            "#/properties/properties/properties/required%20object/required",
+                          params: { missingProperty: "required sub-property" },
+                          message:
+                            "should have required property 'required sub-property'"
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      } else {
+                        var errs_3 = errors;
+                        if (
+                          typeof data2["required sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['required object']['required sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid3 = errors === errs_3;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['required object']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20object/type",
+                        params: { type: "object" },
+                        message: "should be object"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["required object (empty)"];
+                  if (data2 === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required object (empty)" },
+                      message:
+                        "should have required property 'required object (empty)'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (
+                      !data2 ||
+                      typeof data2 !== "object" ||
+                      Array.isArray(data2)
+                    ) {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required object (empty)']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20object%20(empty)/type",
+                        params: { type: "object" },
+                        message: "should be object"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  if (data1["required string"] === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required string" },
+                      message: "should have required property 'required string'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (typeof data1["required string"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") + ".properties['required string']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20string/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                  var data2 = data1["required string regex"];
+                  if (data2 === undefined) {
+                    valid2 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath: (dataPath || "") + ".properties",
+                      schemaPath: "#/properties/properties/required",
+                      params: { missingProperty: "required string regex" },
+                      message:
+                        "should have required property 'required string regex'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_2 = errors;
+                    if (typeof data2 === "string") {
+                      if (!pattern0.test(data2)) {
+                        var err = {
+                          keyword: "pattern",
+                          dataPath:
+                            (dataPath || "") +
+                            ".properties['required string regex']",
+                          schemaPath:
+                            "#/properties/properties/properties/required%20string%20regex/pattern",
+                          params: { pattern: "FOO|BAR" },
+                          message: 'should match pattern "FOO|BAR"'
+                        };
+                        if (vErrors === null) vErrors = [err];
+                        else vErrors.push(err);
+                        errors++;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required string regex']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20string%20regex/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid2 = errors === errs_2;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties",
+                    schemaPath: "#/properties/properties/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
                 }
-              } else {
-                var err = {
-                  keyword: "type",
-                  dataPath: (dataPath || "") + "",
-                  schemaPath: "#/type",
-                  params: { type: "object" },
-                  message: "should be object"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
+                var valid1 = errors === errs_1;
               }
-              validate.errors = vErrors;
-              return errors === 0;
-            };
-            var valid = validate({ properties: props });
-            if (!valid) {
-              throw new Error(JSON.stringify(validate.errors, null, 2));
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + "",
+                schemaPath: "#/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
             }
+            validate.errors = vErrors;
+            return errors === 0;
+          };
+          if (!validate({ properties: props })) {
+            throw new Error(JSON.stringify(validate.errors, null, 2));
           }
           this.analytics.track("Example Event", props, genOptions(context));
         }

--- a/tests/commands/gen-js/__snapshots__/index.umd.js
+++ b/tests/commands/gen-js/__snapshots__/index.umd.js
@@ -21,82 +21,76 @@
     /**
      * Instantiate a wrapper around an analytics library instance
      * @param {Analytics} analytics - The analytics.js library to wrap
-     * @param {Object} config - A configuration object to customize runtime behavior
      */
-    constructor(analytics, options = {}) {
-      const { propertyValidation = true } = options;
+    constructor(analytics) {
       if (!analytics) {
         throw new Error("An instance of analytics.js must be provided");
       }
-      this.analytics = analytics;
-      this.propertyValidation = propertyValidation;
+      this.analytics = analytics || { track: () => null };
     }
     terribleEventName3(props, context) {
-      if (this.propertyValidation) {
-        var validate = function(
-          data,
-          dataPath,
-          parentData,
-          parentDataProperty,
-          rootData
-        ) {
-          "use strict";
-          var vErrors = null;
-          var errors = 0;
-          if (data && typeof data === "object" && !Array.isArray(data)) {
-            var errs__0 = errors;
-            var valid1 = true;
-            var data1 = data.properties;
-            if (data1 === undefined) {
-              valid1 = false;
-              var err = {
-                keyword: "required",
-                dataPath: (dataPath || "") + "",
-                schemaPath: "#/required",
-                params: { missingProperty: "properties" },
-                message: "should have required property 'properties'"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            } else {
-              var errs_1 = errors;
-              if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-                var errs__1 = errors;
-                var valid2 = true;
-              } else {
-                var err = {
-                  keyword: "type",
-                  dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/type",
-                  params: { type: "object" },
-                  message: "should be object"
-                };
-                if (vErrors === null) vErrors = [err];
-                else vErrors.push(err);
-                errors++;
-              }
-              var valid1 = errors === errs_1;
-            }
-          } else {
+      var validate = function(
+        data,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        "use strict";
+        var vErrors = null;
+        var errors = 0;
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          var errs__0 = errors;
+          var valid1 = true;
+          var data1 = data.properties;
+          if (data1 === undefined) {
+            valid1 = false;
             var err = {
-              keyword: "type",
+              keyword: "required",
               dataPath: (dataPath || "") + "",
-              schemaPath: "#/type",
-              params: { type: "object" },
-              message: "should be object"
+              schemaPath: "#/required",
+              params: { missingProperty: "properties" },
+              message: "should have required property 'properties'"
             };
             if (vErrors === null) vErrors = [err];
             else vErrors.push(err);
             errors++;
+          } else {
+            var errs_1 = errors;
+            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+              var errs__1 = errors;
+              var valid2 = true;
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
+            }
+            var valid1 = errors === errs_1;
           }
-          validate.errors = vErrors;
-          return errors === 0;
-        };
-        var valid = validate({ properties: props });
-        if (!valid) {
-          throw new Error(JSON.stringify(validate.errors, null, 2));
+        } else {
+          var err = {
+            keyword: "type",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/type",
+            params: { type: "object" },
+            message: "should be object"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
         }
+        validate.errors = vErrors;
+        return errors === 0;
+      };
+      if (!validate({ properties: props })) {
+        throw new Error(JSON.stringify(validate.errors, null, 2));
       }
       this.analytics.track(
         "42_--terrible==event++name~!3",
@@ -105,965 +99,943 @@
       );
     }
     emptyEvent(props, context) {
-      if (this.propertyValidation) {
-        var validate = function(
-          data,
-          dataPath,
-          parentData,
-          parentDataProperty,
-          rootData
-        ) {
-          "use strict";
-          var vErrors = null;
-          var errors = 0;
-          if (data && typeof data === "object" && !Array.isArray(data)) {
-            var errs__0 = errors;
-            var valid1 = true;
-            var data1 = data.properties;
-            if (data1 === undefined) {
-              valid1 = false;
+      var validate = function(
+        data,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        "use strict";
+        var vErrors = null;
+        var errors = 0;
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          var errs__0 = errors;
+          var valid1 = true;
+          var data1 = data.properties;
+          if (data1 === undefined) {
+            valid1 = false;
+            var err = {
+              keyword: "required",
+              dataPath: (dataPath || "") + "",
+              schemaPath: "#/required",
+              params: { missingProperty: "properties" },
+              message: "should have required property 'properties'"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            var errs_1 = errors;
+            if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
               var err = {
-                keyword: "required",
-                dataPath: (dataPath || "") + "",
-                schemaPath: "#/required",
-                params: { missingProperty: "properties" },
-                message: "should have required property 'properties'"
+                keyword: "type",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/type",
+                params: { type: "object" },
+                message: "should be object"
               };
               if (vErrors === null) vErrors = [err];
               else vErrors.push(err);
               errors++;
-            } else {
-              var errs_1 = errors;
-              if (!data1 || typeof data1 !== "object" || Array.isArray(data1)) {
+            }
+            var valid1 = errors === errs_1;
+          }
+        } else {
+          var err = {
+            keyword: "type",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/type",
+            params: { type: "object" },
+            message: "should be object"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
+        }
+        validate.errors = vErrors;
+        return errors === 0;
+      };
+      if (!validate({ properties: props })) {
+        throw new Error(JSON.stringify(validate.errors, null, 2));
+      }
+      this.analytics.track("Empty Event", props, genOptions(context));
+    }
+    exampleEvent(props, context) {
+      var pattern0 = new RegExp("FOO|BAR");
+      var validate = function(
+        data,
+        dataPath,
+        parentData,
+        parentDataProperty,
+        rootData
+      ) {
+        "use strict";
+        var vErrors = null;
+        var errors = 0;
+        if (data && typeof data === "object" && !Array.isArray(data)) {
+          var errs__0 = errors;
+          var valid1 = true;
+          var data1 = data.properties;
+          if (data1 === undefined) {
+            valid1 = false;
+            var err = {
+              keyword: "required",
+              dataPath: (dataPath || "") + "",
+              schemaPath: "#/required",
+              params: { missingProperty: "properties" },
+              message: "should have required property 'properties'"
+            };
+            if (vErrors === null) vErrors = [err];
+            else vErrors.push(err);
+            errors++;
+          } else {
+            var errs_1 = errors;
+            if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
+              if (data1["required any"] === undefined) {
                 var err = {
-                  keyword: "type",
+                  keyword: "required",
                   dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/type",
-                  params: { type: "object" },
-                  message: "should be object"
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required any" },
+                  message: "should have required property 'required any'"
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
                 errors++;
               }
-              var valid1 = errors === errs_1;
-            }
-          } else {
-            var err = {
-              keyword: "type",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/type",
-              params: { type: "object" },
-              message: "should be object"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
-          }
-          validate.errors = vErrors;
-          return errors === 0;
-        };
-        var valid = validate({ properties: props });
-        if (!valid) {
-          throw new Error(JSON.stringify(validate.errors, null, 2));
-        }
-      }
-      this.analytics.track("Empty Event", props, genOptions(context));
-    }
-    exampleEvent(props, context) {
-      if (this.propertyValidation) {
-        var pattern0 = new RegExp("FOO|BAR");
-        var validate = function(
-          data,
-          dataPath,
-          parentData,
-          parentDataProperty,
-          rootData
-        ) {
-          "use strict";
-          var vErrors = null;
-          var errors = 0;
-          if (data && typeof data === "object" && !Array.isArray(data)) {
-            var errs__0 = errors;
-            var valid1 = true;
-            var data1 = data.properties;
-            if (data1 === undefined) {
-              valid1 = false;
-              var err = {
-                keyword: "required",
-                dataPath: (dataPath || "") + "",
-                schemaPath: "#/required",
-                params: { missingProperty: "properties" },
-                message: "should have required property 'properties'"
-              };
-              if (vErrors === null) vErrors = [err];
-              else vErrors.push(err);
-              errors++;
-            } else {
-              var errs_1 = errors;
-              if (data1 && typeof data1 === "object" && !Array.isArray(data1)) {
-                if (data1["required any"] === undefined) {
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required any" },
-                    message: "should have required property 'required any'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                }
-                var errs__1 = errors;
-                var valid2 = true;
-                var data2 = data1["optional array"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (Array.isArray(data2)) {
-                    var errs__2 = errors;
-                    var valid2;
-                    for (var i2 = 0; i2 < data2.length; i2++) {
-                      var data3 = data2[i2];
-                      var errs_3 = errors;
-                      if (
-                        data3 &&
-                        typeof data3 === "object" &&
-                        !Array.isArray(data3)
-                      ) {
-                        var errs__3 = errors;
-                        var valid4 = true;
-                        if (data3["optional sub-property"] !== undefined) {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["optional sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['optional array'][" +
-                                i2 +
-                                "]['optional sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
-                        }
-                        if (data3["required sub-property"] === undefined) {
-                          valid4 = false;
+              var errs__1 = errors;
+              var valid2 = true;
+              var data2 = data1["optional array"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (Array.isArray(data2)) {
+                  var errs__2 = errors;
+                  var valid2;
+                  for (var i2 = 0; i2 < data2.length; i2++) {
+                    var data3 = data2[i2];
+                    var errs_3 = errors;
+                    if (
+                      data3 &&
+                      typeof data3 === "object" &&
+                      !Array.isArray(data3)
+                    ) {
+                      var errs__3 = errors;
+                      var valid4 = true;
+                      if (data3["optional sub-property"] !== undefined) {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["optional sub-property"] !== "string"
+                        ) {
                           var err = {
-                            keyword: "required",
+                            keyword: "type",
                             dataPath:
                               (dataPath || "") +
                               ".properties['optional array'][" +
                               i2 +
-                              "]",
+                              "]['optional sub-property']",
                             schemaPath:
-                              "#/properties/properties/properties/optional%20array/items/required",
-                            params: {
-                              missingProperty: "required sub-property"
-                            },
-                            message:
-                              "should have required property 'required sub-property'"
+                              "#/properties/properties/properties/optional%20array/items/properties/optional%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
                           };
                           if (vErrors === null) vErrors = [err];
                           else vErrors.push(err);
                           errors++;
-                        } else {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["required sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['optional array'][" +
-                                i2 +
-                                "]['required sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
                         }
-                      } else {
+                        var valid4 = errors === errs_4;
+                      }
+                      if (data3["required sub-property"] === undefined) {
+                        valid4 = false;
                         var err = {
-                          keyword: "type",
+                          keyword: "required",
                           dataPath:
                             (dataPath || "") +
                             ".properties['optional array'][" +
                             i2 +
                             "]",
                           schemaPath:
-                            "#/properties/properties/properties/optional%20array/items/type",
-                          params: { type: "object" },
-                          message: "should be object"
+                            "#/properties/properties/properties/optional%20array/items/required",
+                          params: { missingProperty: "required sub-property" },
+                          message:
+                            "should have required property 'required sub-property'"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional array']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20array/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional array (empty)"] !== undefined) {
-                  var errs_2 = errors;
-                  if (!Array.isArray(data1["optional array (empty)"])) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional array (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20array%20(empty)/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional boolean"] !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data1["optional boolean"] !== "boolean") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional boolean']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20boolean/type",
-                      params: { type: "boolean" },
-                      message: "should be boolean"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional int"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (
-                    typeof data2 !== "number" ||
-                    data2 % 1 ||
-                    data2 !== data2
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional int']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20int/type",
-                      params: { type: "integer" },
-                      message: "should be integer"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional number"] !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data1["optional number"] !== "number") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional number']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20number/type",
-                      params: { type: "number" },
-                      message: "should be number"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional object"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (
-                    data2 &&
-                    typeof data2 === "object" &&
-                    !Array.isArray(data2)
-                  ) {
-                    var errs__2 = errors;
-                    var valid3 = true;
-                    if (data2["optional sub-property"] !== undefined) {
-                      var errs_3 = errors;
-                      if (typeof data2["optional sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional object']['optional sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                    if (data2["required sub-property"] === undefined) {
-                      valid3 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath:
-                          (dataPath || "") + ".properties['optional object']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20object/required",
-                        params: { missingProperty: "required sub-property" },
-                        message:
-                          "should have required property 'required sub-property'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    } else {
-                      var errs_3 = errors;
-                      if (typeof data2["required sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['optional object']['required sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional object']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20object/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional object (empty)"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (
-                    !data2 ||
-                    typeof data2 !== "object" ||
-                    Array.isArray(data2)
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional object (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20object%20(empty)/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["optional string"] !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data1["optional string"] !== "string") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['optional string']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20string/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["optional string regex"];
-                if (data2 !== undefined) {
-                  var errs_2 = errors;
-                  if (typeof data2 === "string") {
-                    if (!pattern0.test(data2)) {
-                      var err = {
-                        keyword: "pattern",
-                        dataPath:
-                          (dataPath || "") +
-                          ".properties['optional string regex']",
-                        schemaPath:
-                          "#/properties/properties/properties/optional%20string%20regex/pattern",
-                        params: { pattern: "FOO|BAR" },
-                        message: 'should match pattern "FOO|BAR"'
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['optional string regex']",
-                      schemaPath:
-                        "#/properties/properties/properties/optional%20string%20regex/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required array"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required array" },
-                    message: "should have required property 'required array'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (Array.isArray(data2)) {
-                    var errs__2 = errors;
-                    var valid2;
-                    for (var i2 = 0; i2 < data2.length; i2++) {
-                      var data3 = data2[i2];
-                      var errs_3 = errors;
-                      if (
-                        data3 &&
-                        typeof data3 === "object" &&
-                        !Array.isArray(data3)
-                      ) {
-                        var errs__3 = errors;
-                        var valid4 = true;
-                        if (data3["optional sub-property"] !== undefined) {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["optional sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['required array'][" +
-                                i2 +
-                                "]['optional sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
-                        }
-                        if (data3["required sub-property"] === undefined) {
-                          valid4 = false;
+                      } else {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["required sub-property"] !== "string"
+                        ) {
                           var err = {
-                            keyword: "required",
+                            keyword: "type",
                             dataPath:
                               (dataPath || "") +
-                              ".properties['required array'][" +
+                              ".properties['optional array'][" +
                               i2 +
-                              "]",
+                              "]['required sub-property']",
                             schemaPath:
-                              "#/properties/properties/properties/required%20array/items/required",
-                            params: {
-                              missingProperty: "required sub-property"
-                            },
-                            message:
-                              "should have required property 'required sub-property'"
+                              "#/properties/properties/properties/optional%20array/items/properties/required%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
                           };
                           if (vErrors === null) vErrors = [err];
                           else vErrors.push(err);
                           errors++;
-                        } else {
-                          var errs_4 = errors;
-                          if (
-                            typeof data3["required sub-property"] !== "string"
-                          ) {
-                            var err = {
-                              keyword: "type",
-                              dataPath:
-                                (dataPath || "") +
-                                ".properties['required array'][" +
-                                i2 +
-                                "]['required sub-property']",
-                              schemaPath:
-                                "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
-                              params: { type: "string" },
-                              message: "should be string"
-                            };
-                            if (vErrors === null) vErrors = [err];
-                            else vErrors.push(err);
-                            errors++;
-                          }
-                          var valid4 = errors === errs_4;
                         }
-                      } else {
+                        var valid4 = errors === errs_4;
+                      }
+                    } else {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional array'][" +
+                          i2 +
+                          "]",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20array/items/type",
+                        params: { type: "object" },
+                        message: "should be object"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional array']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20array/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional array (empty)"] !== undefined) {
+                var errs_2 = errors;
+                if (!Array.isArray(data1["optional array (empty)"])) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['optional array (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20array%20(empty)/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional boolean"] !== undefined) {
+                var errs_2 = errors;
+                if (typeof data1["optional boolean"] !== "boolean") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional boolean']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20boolean/type",
+                    params: { type: "boolean" },
+                    message: "should be boolean"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional int"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                  var err = {
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties['optional int']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20int/type",
+                    params: { type: "integer" },
+                    message: "should be integer"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional number"] !== undefined) {
+                var errs_2 = errors;
+                if (typeof data1["optional number"] !== "number") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional number']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20number/type",
+                    params: { type: "number" },
+                    message: "should be number"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional object"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (
+                  data2 &&
+                  typeof data2 === "object" &&
+                  !Array.isArray(data2)
+                ) {
+                  var errs__2 = errors;
+                  var valid3 = true;
+                  if (data2["optional sub-property"] !== undefined) {
+                    var errs_3 = errors;
+                    if (typeof data2["optional sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional object']['optional sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20object/properties/optional%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                  if (data2["required sub-property"] === undefined) {
+                    valid3 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath:
+                        (dataPath || "") + ".properties['optional object']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20object/required",
+                      params: { missingProperty: "required sub-property" },
+                      message:
+                        "should have required property 'required sub-property'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_3 = errors;
+                    if (typeof data2["required sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['optional object']['required sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/optional%20object/properties/required%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional object']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20object/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional object (empty)"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (
+                  !data2 ||
+                  typeof data2 !== "object" ||
+                  Array.isArray(data2)
+                ) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['optional object (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20object%20(empty)/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["optional string"] !== undefined) {
+                var errs_2 = errors;
+                if (typeof data1["optional string"] !== "string") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional string']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20string/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["optional string regex"];
+              if (data2 !== undefined) {
+                var errs_2 = errors;
+                if (typeof data2 === "string") {
+                  if (!pattern0.test(data2)) {
+                    var err = {
+                      keyword: "pattern",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['optional string regex']",
+                      schemaPath:
+                        "#/properties/properties/properties/optional%20string%20regex/pattern",
+                      params: { pattern: "FOO|BAR" },
+                      message: 'should match pattern "FOO|BAR"'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['optional string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/optional%20string%20regex/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required array"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required array" },
+                  message: "should have required property 'required array'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (Array.isArray(data2)) {
+                  var errs__2 = errors;
+                  var valid2;
+                  for (var i2 = 0; i2 < data2.length; i2++) {
+                    var data3 = data2[i2];
+                    var errs_3 = errors;
+                    if (
+                      data3 &&
+                      typeof data3 === "object" &&
+                      !Array.isArray(data3)
+                    ) {
+                      var errs__3 = errors;
+                      var valid4 = true;
+                      if (data3["optional sub-property"] !== undefined) {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["optional sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['required array'][" +
+                              i2 +
+                              "]['optional sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/required%20array/items/properties/optional%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid4 = errors === errs_4;
+                      }
+                      if (data3["required sub-property"] === undefined) {
+                        valid4 = false;
                         var err = {
-                          keyword: "type",
+                          keyword: "required",
                           dataPath:
                             (dataPath || "") +
                             ".properties['required array'][" +
                             i2 +
                             "]",
                           schemaPath:
-                            "#/properties/properties/properties/required%20array/items/type",
-                          params: { type: "object" },
-                          message: "should be object"
+                            "#/properties/properties/properties/required%20array/items/required",
+                          params: { missingProperty: "required sub-property" },
+                          message:
+                            "should have required property 'required sub-property'"
                         };
                         if (vErrors === null) vErrors = [err];
                         else vErrors.push(err);
                         errors++;
+                      } else {
+                        var errs_4 = errors;
+                        if (
+                          typeof data3["required sub-property"] !== "string"
+                        ) {
+                          var err = {
+                            keyword: "type",
+                            dataPath:
+                              (dataPath || "") +
+                              ".properties['required array'][" +
+                              i2 +
+                              "]['required sub-property']",
+                            schemaPath:
+                              "#/properties/properties/properties/required%20array/items/properties/required%20sub-property/type",
+                            params: { type: "string" },
+                            message: "should be string"
+                          };
+                          if (vErrors === null) vErrors = [err];
+                          else vErrors.push(err);
+                          errors++;
+                        }
+                        var valid4 = errors === errs_4;
                       }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required array']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20array/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required array (empty)"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required array (empty)" },
-                    message:
-                      "should have required property 'required array (empty)'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (!Array.isArray(data1["required array (empty)"])) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['required array (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20array%20(empty)/type",
-                      params: { type: "array" },
-                      message: "should be array"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required boolean"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required boolean" },
-                    message: "should have required property 'required boolean'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data1["required boolean"] !== "boolean") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required boolean']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20boolean/type",
-                      params: { type: "boolean" },
-                      message: "should be boolean"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required int"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required int" },
-                    message: "should have required property 'required int'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (
-                    typeof data2 !== "number" ||
-                    data2 % 1 ||
-                    data2 !== data2
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required int']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20int/type",
-                      params: { type: "integer" },
-                      message: "should be integer"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required number"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required number" },
-                    message: "should have required property 'required number'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data1["required number"] !== "number") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required number']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20number/type",
-                      params: { type: "number" },
-                      message: "should be number"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required object"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required object" },
-                    message: "should have required property 'required object'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (
-                    data2 &&
-                    typeof data2 === "object" &&
-                    !Array.isArray(data2)
-                  ) {
-                    var errs__2 = errors;
-                    var valid3 = true;
-                    if (data2["optional sub-property"] !== undefined) {
-                      var errs_3 = errors;
-                      if (typeof data2["optional sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required object']['optional sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                    if (data2["required sub-property"] === undefined) {
-                      valid3 = false;
-                      var err = {
-                        keyword: "required",
-                        dataPath:
-                          (dataPath || "") + ".properties['required object']",
-                        schemaPath:
-                          "#/properties/properties/properties/required%20object/required",
-                        params: { missingProperty: "required sub-property" },
-                        message:
-                          "should have required property 'required sub-property'"
-                      };
-                      if (vErrors === null) vErrors = [err];
-                      else vErrors.push(err);
-                      errors++;
                     } else {
-                      var errs_3 = errors;
-                      if (typeof data2["required sub-property"] !== "string") {
-                        var err = {
-                          keyword: "type",
-                          dataPath:
-                            (dataPath || "") +
-                            ".properties['required object']['required sub-property']",
-                          schemaPath:
-                            "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
-                          params: { type: "string" },
-                          message: "should be string"
-                        };
-                        if (vErrors === null) vErrors = [err];
-                        else vErrors.push(err);
-                        errors++;
-                      }
-                      var valid3 = errors === errs_3;
-                    }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required object']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20object/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required object (empty)"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required object (empty)" },
-                    message:
-                      "should have required property 'required object (empty)'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (
-                    !data2 ||
-                    typeof data2 !== "object" ||
-                    Array.isArray(data2)
-                  ) {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['required object (empty)']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20object%20(empty)/type",
-                      params: { type: "object" },
-                      message: "should be object"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                if (data1["required string"] === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required string" },
-                    message: "should have required property 'required string'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data1["required string"] !== "string") {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") + ".properties['required string']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20string/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
-                  }
-                  var valid2 = errors === errs_2;
-                }
-                var data2 = data1["required string regex"];
-                if (data2 === undefined) {
-                  valid2 = false;
-                  var err = {
-                    keyword: "required",
-                    dataPath: (dataPath || "") + ".properties",
-                    schemaPath: "#/properties/properties/required",
-                    params: { missingProperty: "required string regex" },
-                    message:
-                      "should have required property 'required string regex'"
-                  };
-                  if (vErrors === null) vErrors = [err];
-                  else vErrors.push(err);
-                  errors++;
-                } else {
-                  var errs_2 = errors;
-                  if (typeof data2 === "string") {
-                    if (!pattern0.test(data2)) {
                       var err = {
-                        keyword: "pattern",
+                        keyword: "type",
                         dataPath:
                           (dataPath || "") +
-                          ".properties['required string regex']",
+                          ".properties['required array'][" +
+                          i2 +
+                          "]",
                         schemaPath:
-                          "#/properties/properties/properties/required%20string%20regex/pattern",
-                        params: { pattern: "FOO|BAR" },
-                        message: 'should match pattern "FOO|BAR"'
+                          "#/properties/properties/properties/required%20array/items/type",
+                        params: { type: "object" },
+                        message: "should be object"
                       };
                       if (vErrors === null) vErrors = [err];
                       else vErrors.push(err);
                       errors++;
                     }
-                  } else {
-                    var err = {
-                      keyword: "type",
-                      dataPath:
-                        (dataPath || "") +
-                        ".properties['required string regex']",
-                      schemaPath:
-                        "#/properties/properties/properties/required%20string%20regex/type",
-                      params: { type: "string" },
-                      message: "should be string"
-                    };
-                    if (vErrors === null) vErrors = [err];
-                    else vErrors.push(err);
-                    errors++;
+                    var valid3 = errors === errs_3;
                   }
-                  var valid2 = errors === errs_2;
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required array']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20array/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
                 }
-              } else {
+                var valid2 = errors === errs_2;
+              }
+              if (data1["required array (empty)"] === undefined) {
+                valid2 = false;
                 var err = {
-                  keyword: "type",
+                  keyword: "required",
                   dataPath: (dataPath || "") + ".properties",
-                  schemaPath: "#/properties/properties/type",
-                  params: { type: "object" },
-                  message: "should be object"
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required array (empty)" },
+                  message:
+                    "should have required property 'required array (empty)'"
                 };
                 if (vErrors === null) vErrors = [err];
                 else vErrors.push(err);
                 errors++;
+              } else {
+                var errs_2 = errors;
+                if (!Array.isArray(data1["required array (empty)"])) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['required array (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20array%20(empty)/type",
+                    params: { type: "array" },
+                    message: "should be array"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
               }
-              var valid1 = errors === errs_1;
+              if (data1["required boolean"] === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required boolean" },
+                  message: "should have required property 'required boolean'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data1["required boolean"] !== "boolean") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required boolean']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20boolean/type",
+                    params: { type: "boolean" },
+                    message: "should be boolean"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required int"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required int" },
+                  message: "should have required property 'required int'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data2 !== "number" || data2 % 1 || data2 !== data2) {
+                  var err = {
+                    keyword: "type",
+                    dataPath: (dataPath || "") + ".properties['required int']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20int/type",
+                    params: { type: "integer" },
+                    message: "should be integer"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["required number"] === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required number" },
+                  message: "should have required property 'required number'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data1["required number"] !== "number") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required number']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20number/type",
+                    params: { type: "number" },
+                    message: "should be number"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required object"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required object" },
+                  message: "should have required property 'required object'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (
+                  data2 &&
+                  typeof data2 === "object" &&
+                  !Array.isArray(data2)
+                ) {
+                  var errs__2 = errors;
+                  var valid3 = true;
+                  if (data2["optional sub-property"] !== undefined) {
+                    var errs_3 = errors;
+                    if (typeof data2["optional sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required object']['optional sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20object/properties/optional%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                  if (data2["required sub-property"] === undefined) {
+                    valid3 = false;
+                    var err = {
+                      keyword: "required",
+                      dataPath:
+                        (dataPath || "") + ".properties['required object']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20object/required",
+                      params: { missingProperty: "required sub-property" },
+                      message:
+                        "should have required property 'required sub-property'"
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  } else {
+                    var errs_3 = errors;
+                    if (typeof data2["required sub-property"] !== "string") {
+                      var err = {
+                        keyword: "type",
+                        dataPath:
+                          (dataPath || "") +
+                          ".properties['required object']['required sub-property']",
+                        schemaPath:
+                          "#/properties/properties/properties/required%20object/properties/required%20sub-property/type",
+                        params: { type: "string" },
+                        message: "should be string"
+                      };
+                      if (vErrors === null) vErrors = [err];
+                      else vErrors.push(err);
+                      errors++;
+                    }
+                    var valid3 = errors === errs_3;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required object']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20object/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required object (empty)"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required object (empty)" },
+                  message:
+                    "should have required property 'required object (empty)'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (
+                  !data2 ||
+                  typeof data2 !== "object" ||
+                  Array.isArray(data2)
+                ) {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") +
+                      ".properties['required object (empty)']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20object%20(empty)/type",
+                    params: { type: "object" },
+                    message: "should be object"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              if (data1["required string"] === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required string" },
+                  message: "should have required property 'required string'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data1["required string"] !== "string") {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required string']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20string/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+              var data2 = data1["required string regex"];
+              if (data2 === undefined) {
+                valid2 = false;
+                var err = {
+                  keyword: "required",
+                  dataPath: (dataPath || "") + ".properties",
+                  schemaPath: "#/properties/properties/required",
+                  params: { missingProperty: "required string regex" },
+                  message:
+                    "should have required property 'required string regex'"
+                };
+                if (vErrors === null) vErrors = [err];
+                else vErrors.push(err);
+                errors++;
+              } else {
+                var errs_2 = errors;
+                if (typeof data2 === "string") {
+                  if (!pattern0.test(data2)) {
+                    var err = {
+                      keyword: "pattern",
+                      dataPath:
+                        (dataPath || "") +
+                        ".properties['required string regex']",
+                      schemaPath:
+                        "#/properties/properties/properties/required%20string%20regex/pattern",
+                      params: { pattern: "FOO|BAR" },
+                      message: 'should match pattern "FOO|BAR"'
+                    };
+                    if (vErrors === null) vErrors = [err];
+                    else vErrors.push(err);
+                    errors++;
+                  }
+                } else {
+                  var err = {
+                    keyword: "type",
+                    dataPath:
+                      (dataPath || "") + ".properties['required string regex']",
+                    schemaPath:
+                      "#/properties/properties/properties/required%20string%20regex/type",
+                    params: { type: "string" },
+                    message: "should be string"
+                  };
+                  if (vErrors === null) vErrors = [err];
+                  else vErrors.push(err);
+                  errors++;
+                }
+                var valid2 = errors === errs_2;
+              }
+            } else {
+              var err = {
+                keyword: "type",
+                dataPath: (dataPath || "") + ".properties",
+                schemaPath: "#/properties/properties/type",
+                params: { type: "object" },
+                message: "should be object"
+              };
+              if (vErrors === null) vErrors = [err];
+              else vErrors.push(err);
+              errors++;
             }
-          } else {
-            var err = {
-              keyword: "type",
-              dataPath: (dataPath || "") + "",
-              schemaPath: "#/type",
-              params: { type: "object" },
-              message: "should be object"
-            };
-            if (vErrors === null) vErrors = [err];
-            else vErrors.push(err);
-            errors++;
+            var valid1 = errors === errs_1;
           }
-          validate.errors = vErrors;
-          return errors === 0;
-        };
-        var valid = validate({ properties: props });
-        if (!valid) {
-          throw new Error(JSON.stringify(validate.errors, null, 2));
+        } else {
+          var err = {
+            keyword: "type",
+            dataPath: (dataPath || "") + "",
+            schemaPath: "#/type",
+            params: { type: "object" },
+            message: "should be object"
+          };
+          if (vErrors === null) vErrors = [err];
+          else vErrors.push(err);
+          errors++;
         }
+        validate.errors = vErrors;
+        return errors === 0;
+      };
+      if (!validate({ properties: props })) {
+        throw new Error(JSON.stringify(validate.errors, null, 2));
       }
       this.analytics.track("Example Event", props, genOptions(context));
     }

--- a/tests/commands/gen-js/library.test.ts
+++ b/tests/commands/gen-js/library.test.ts
@@ -34,3 +34,17 @@ test('genJS - compiled output matches snapshot (analytics-node)', async () => {
     'index.node.js'
   )
 })
+
+test('genJS - compiled output matches snapshot - no runtime validation', async () => {
+  await testSnapshotSingleFile(
+    events => genJS(events, ScriptTarget.ESNext, ModuleKind.ESNext, Client.js, false),
+    'index.prod.js'
+  )
+})
+
+test('genJS - compiled output matches snapshot - no runtime validation (analytics-node)', async () => {
+  await testSnapshotSingleFile(
+    events => genJS(events, ScriptTarget.ES2017, ModuleKind.CommonJS, Client.node, false),
+    'index.prod.node.js'
+  )
+})


### PR DESCRIPTION
When generating a JS client, you can now pass in a `--runtimeValidation <true|false>` flag which toggles whether or not property validation logic will be included in the generated Typewriter client.

This allows you to generate a production version of your Typewriter client with all validation logic stripped out. This has the benefits of:
- Reducing the bundle size for your end users
- Increasing the performance of your analytics (the client just performs a pass-through to the underlying Segment analytics instance).

BREAKING CHANGE: the run-time flag, `options.propertyValidation`, which previously could be used to disable validation at run-time, has been removed. It's recommended that you use the build-time flag instead.

