### PR TITLE
fix: crash in Android example on back button

### DIFF
--- a/examples/gen-android/java/README.md
+++ b/examples/gen-android/java/README.md
@@ -4,7 +4,7 @@ This example repo demonstrates how to setup and use Typewriter in an Android Jav
 
 ## Example Setup
 
-Update the Segment write key in [MainActivity.java](app/src/main/java/com/segment/typewriterexample/MainActivity.java#L20) for the source you want to report analytics to:
+Update the Segment write key in [MainActivity.java](app/src/main/java/com/segment/typewriterexample/TypewriterApplication.java#L8) for the source you want to report analytics to:
 
 ```java
 private static final String SEGMENT_WRITE_KEY = "<Your source write key>";

--- a/examples/gen-android/java/app/src/main/AndroidManifest.xml
+++ b/examples/gen-android/java/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.segment.typewriterexample">
 
     <application
+        android:name=".TypewriterApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/MainActivity.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/MainActivity.java
@@ -17,7 +17,6 @@ import java.util.UUID;
 
 public class MainActivity extends AppCompatActivity {
     public static final String EXTRA_MESSAGE = "com.segment.PRODUCT_NAME";
-    private static final String SEGMENT_WRITE_KEY = "51GMfJ49iiQQPmzj227krjW9ch9gKpMx";
     private KicksAppAnalytics kicksAppAnalytics;
 
     @Override
@@ -25,11 +24,7 @@ public class MainActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        Analytics analytics = new Analytics.Builder(this, SEGMENT_WRITE_KEY)
-                .trackApplicationLifecycleEvents()
-                .recordScreenViews()
-                .build();
-        this.kicksAppAnalytics = new KicksAppAnalytics(analytics);
+        this.kicksAppAnalytics = new KicksAppAnalytics(Analytics.with(this));
     }
 
     /** Called when the user taps the Send button */

--- a/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/TypewriterApplication.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/TypewriterApplication.java
@@ -1,0 +1,20 @@
+package com.segment.typewriterexample;
+
+import android.app.Application;
+
+import com.segment.analytics.Analytics;
+
+public class TypewriterApplication extends Application {
+    private static final String SEGMENT_WRITE_KEY = "51GMfJ49iiQQPmzj227krjW9ch9gKpMx";
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+
+        Analytics analytics = new Analytics.Builder(this, SEGMENT_WRITE_KEY)
+                .trackApplicationLifecycleEvents()
+                .recordScreenViews()
+                .build();
+        Analytics.setSingletonInstance(analytics);
+    }
+}


### PR DESCRIPTION
The Android example was misconfigured to regenerate an Analytics instance every time the `MainActivity` was loaded. This moves this logic into the `Application` class where it will only be executed once, following analytics-android best practices.