### PR TITLE
fix: add integrations to node.js and support the AppsFlyer exception [SCH-1407]

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -6,7 +6,13 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: { [key: string]: boolean };
+  integrations: {
+    All: boolean;
+    AppsFlyer: {
+      appsFlyerId: string;
+    };
+    [key: string]: boolean | { [key: string]: string };
+  };
 }
 
 export interface FeedViewed {

--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -7,8 +7,8 @@ export interface SegmentOptions {
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
   integrations: {
-    All: boolean;
-    AppsFlyer: {
+    All?: boolean;
+    AppsFlyer?: {
       appsFlyerId: string;
     };
     [key: string]: boolean | { [key: string]: string };

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -51,8 +51,8 @@ export interface TrackMessage<PropertiesType> {
    * https://segment.com/docs/spec/common/#integrations
    */
   integrations?: {
-    All: boolean;
-    AppsFlyer: {
+    All?: boolean;
+    AppsFlyer?: {
       appsFlyerId: string;
     };
     [key: string]: boolean | { [key: string]: string };

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -44,6 +44,19 @@ export interface TrackMessage<PropertiesType> {
    * https://segment.com/docs/spec/common/#context
    */
   context?: Object;
+  /**
+   * A dictionary of destination names that the message should be sent to.
+   * By default all destinations are enabled. 'All' is a special key that
+   * applies when no key for a specific destination is found.
+   * https://segment.com/docs/spec/common/#integrations
+   */
+  integrations?: {
+    All: boolean;
+    AppsFlyer: {
+      appsFlyerId: string;
+    };
+    [key: string]: boolean | { [key: string]: string };
+  };
 }
 
 export interface OrderCompleted {

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -6,7 +6,13 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: { [key: string]: boolean };
+  integrations: {
+    All: boolean;
+    AppsFlyer: {
+      appsFlyerId: string;
+    };
+    [key: string]: boolean | { [key: string]: string };
+  };
 }
 
 export interface FeedViewed {

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -7,8 +7,8 @@ export interface SegmentOptions {
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
   integrations: {
-    All: boolean;
-    AppsFlyer: {
+    All?: boolean;
+    AppsFlyer?: {
       appsFlyerId: string;
     };
     [key: string]: boolean | { [key: string]: string };

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -72,17 +72,36 @@ export interface TrackMessage<PropertiesType> {
    * https://segment.com/docs/spec/common/#context
    */
   context?: Object;
+  /**
+   * A dictionary of destination names that the message should be sent to.
+   * By default all destinations are enabled. 'All' is a special key that
+   * applies when no key for a specific destination is found.
+   * https://segment.com/docs/spec/common/#integrations
+   */
+  integrations?: {
+    All: boolean
+		AppsFlyer: {
+			appsFlyerId: string
+		}
+		[key: string]: boolean | { [key: string]: string }
+	}
 }`
 
 const ajsTopLevels = `export type AnalyticsJSCallback = () => void
 
 /** A dictionary of options. For example, enable or disable specific destinations for the call. */
 export interface SegmentOptions {
-  /**
+	/**
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: { [key: string]: boolean }
+	integrations: {
+    All: boolean
+		AppsFlyer: {
+			appsFlyerId: string
+		}
+		[key: string]: boolean | { [key: string]: string }
+	}
 }`
 
 /** Target language for a.js TypeScript Declarations */

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -79,29 +79,29 @@ export interface TrackMessage<PropertiesType> {
    * https://segment.com/docs/spec/common/#integrations
    */
   integrations?: {
-    All: boolean
-		AppsFlyer: {
-			appsFlyerId: string
-		}
-		[key: string]: boolean | { [key: string]: string }
-	}
+    All?: boolean
+    AppsFlyer?: {
+      appsFlyerId: string
+    }
+    [key: string]: boolean | { [key: string]: string }
+  }
 }`
 
 const ajsTopLevels = `export type AnalyticsJSCallback = () => void
 
 /** A dictionary of options. For example, enable or disable specific destinations for the call. */
 export interface SegmentOptions {
-	/**
+  /**
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-	integrations: {
-    All: boolean
-		AppsFlyer: {
-			appsFlyerId: string
-		}
-		[key: string]: boolean | { [key: string]: string }
-	}
+  integrations: {
+    All?: boolean
+    AppsFlyer?: {
+      appsFlyerId: string
+    }
+    [key: string]: boolean | { [key: string]: string }
+  }
 }`
 
 /** Target language for a.js TypeScript Declarations */

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -7,8 +7,8 @@ export interface SegmentOptions {
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
   integrations: {
-    All: boolean;
-    AppsFlyer: {
+    All?: boolean;
+    AppsFlyer?: {
       appsFlyerId: string;
     };
     [key: string]: boolean | { [key: string]: string };

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -6,7 +6,13 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: { [key: string]: boolean };
+  integrations: {
+    All: boolean;
+    AppsFlyer: {
+      appsFlyerId: string;
+    };
+    [key: string]: boolean | { [key: string]: string };
+  };
 }
 
 export interface The42_TerribleEventName3 {

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -51,8 +51,8 @@ export interface TrackMessage<PropertiesType> {
    * https://segment.com/docs/spec/common/#integrations
    */
   integrations?: {
-    All: boolean;
-    AppsFlyer: {
+    All?: boolean;
+    AppsFlyer?: {
       appsFlyerId: string;
     };
     [key: string]: boolean | { [key: string]: string };

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -44,6 +44,19 @@ export interface TrackMessage<PropertiesType> {
    * https://segment.com/docs/spec/common/#context
    */
   context?: Object;
+  /**
+   * A dictionary of destination names that the message should be sent to.
+   * By default all destinations are enabled. 'All' is a special key that
+   * applies when no key for a specific destination is found.
+   * https://segment.com/docs/spec/common/#integrations
+   */
+  integrations?: {
+    All: boolean;
+    AppsFlyer: {
+      appsFlyerId: string;
+    };
+    [key: string]: boolean | { [key: string]: string };
+  };
 }
 
 export interface The42_TerribleEventName3 {


### PR DESCRIPTION
This adds `integrations` to the Node.JS TypeScript declarations, along with `AppsFlyer` as an exception. This also adds `All` as a convenience.