### PR TITLE
move typescript to a production dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "request-promise-native": "^1.0.5",
     "sort-keys": "^2.0.0",
     "ts-node": "^6.1.0",
+    "typescript": "^3.2.2",
     "yargs": "^12.0.2"
   },
   "devDependencies": {
@@ -100,6 +101,7 @@
     "jest": "^23.6",
     "jest-file-snapshot": "^0.2.1",
     "lint-staged": "^7.3.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "^1.5.3",
     "release-it": "^7.5.0",
     "test": "^0.6.0",
@@ -107,9 +109,7 @@
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.13.0",
     "tslint-config-standard": "^7.0.0",
-    "tslint-plugin-prettier": "^2.0.0",
-    "typescript": "^3.1.1",
-    "npm-run-all": "^4.1.5"
+    "tslint-plugin-prettier": "^2.0.0"
   },
   "engines": {
     "node": ">=8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7437,10 +7437,10 @@ typescript@*:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.3.tgz#01b70247a6d3c2467f70c45795ef5ea18ce191d5"
   integrity sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==
 
-typescript@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
-  integrity sha512-gOoGJWbNnFAfP9FlrSV63LYD5DJqYJHG5ky1kOXSl3pCImn4rqWy/flyq1BRd4iChQsoCqjbQaqtmXO4yCVPCA==
+typescript@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
+  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
 
 typescript@~3.0.3:
   version "3.0.3"


### PR DESCRIPTION
Hey TypeWriter team!

This PR moves `typescript` into regular ol' production `"dependencies"`. I believe importing it the dist lib causes problems when consumers install using `yarn install --production` mode.

The problem might be exacerbated by the fact that I'm using `typescript` as a dev-dep in this project, too. Hard to tell.