### PR TITLE
Enable strict + fix `strictNullCheck` TS errors

### DIFF
--- a/examples/gen-js/ts/components/Layout.tsx
+++ b/examples/gen-js/ts/components/Layout.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 
-export default (props) => (
+const Layout: React.SFC<{}> = (props) => (
   <div>
     <Head>
       <meta name='viewport' content='width=device-width, initial-scale=1' />
@@ -15,3 +15,5 @@ export default (props) => (
     {props.children}
   </div>
 )
+
+export default Layout

--- a/examples/gen-js/ts/components/Modal.tsx
+++ b/examples/gen-js/ts/components/Modal.tsx
@@ -1,13 +1,18 @@
 import React from 'react'
 import Frame from './Frame'
 
-export default class extends React.Component<any> {
+interface Props {
+  id: string
+  onDismiss: () => void
+}
+
+export default class extends React.Component<Props> {
   private shim: any
   private photoWrap: any
 
   public render () {
     return (
-      <div ref={el => (this.shim = el)} className='shim' onClick={(e) => this.dismiss(e)}>
+      <div ref={el => (this.shim = el)} className='shim' onClick={(e: React.MouseEvent<HTMLDivElement>) => this.dismiss(e)}>
         <div ref={el => (this.photoWrap = el)} className='photo'>
           <Frame id={this.props.id} />
         </div>
@@ -32,7 +37,7 @@ export default class extends React.Component<any> {
     )
   }
 
-  private dismiss = (e) => {
+  private dismiss = (e: React.MouseEvent) => {
     if (this.shim === e.target ||
        this.photoWrap === e.target) {
       if (this.props.onDismiss) {

--- a/examples/gen-js/ts/pages/index.tsx
+++ b/examples/gen-js/ts/pages/index.tsx
@@ -20,7 +20,7 @@ export default class extends React.Component<any> {
     Router.push('/')
   }
 
-  public showPhoto (e, id) {
+  public showPhoto (e: React.MouseEvent, id: string) {
     e.preventDefault()
     Router.push(`/?photoId=${id}`, `/photo?id=${id}`)
   }
@@ -39,12 +39,12 @@ export default class extends React.Component<any> {
               />
           }
           {
-            photos.map((id) => (
+            photos.map((id: string) => (
               <div key={id} className='photo'>
                 <a
                   className='photoLink'
                   href={`/photo?id=${id}`}
-                  onClick={(e) => this.showPhoto(e, id)}
+                  onClick={(e: React.MouseEvent<HTMLAnchorElement>) => this.showPhoto(e, id)}
                 >
                   {id}
                 </a>

--- a/examples/gen-js/ts/tsconfig.json
+++ b/examples/gen-js/ts/tsconfig.json
@@ -5,6 +5,8 @@
     "module": "esnext",
     "jsx": "preserve",
     "allowJs": true,
+    "strict": true,
+    "strictNullChecks": true,
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,
@@ -13,6 +15,7 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "skipLibCheck": true,
+    "outDir": "dist",
     "baseUrl": ".",
     "typeRoots": ["./node_modules/@types"],
     "lib": ["dom", "es2015", "es2016"]

--- a/src/commands/gen-js/library.ts
+++ b/src/commands/gen-js/library.ts
@@ -57,9 +57,9 @@ export function genJS(
       const compiledValidationSource: any = ajv.compile(preprocessRules(rules)).source
       const compiledValidationFn = compiledValidationSource.code.replace(/return validate;/, '')
 
-      let parameters: string
-      let trackCall: string
-      let validateCall: string
+      let parameters = ''
+      let trackCall = ''
+      let validateCall = ''
       if (client === Client.js) {
         parameters = 'props, context'
         trackCall = `this.analytics.track('${name}', props, genOptions(context))`

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -71,7 +71,7 @@ export interface TrackMessage<PropertiesType> {
    * A dictionary of extra context to attach to the call.
    * https://segment.com/docs/spec/common/#context
    */
-  context?: Object;
+  context?: any;
   /**
    * A dictionary of destination names that the message should be sent to.
    * By default all destinations are enabled. 'All' is a special key that

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -1,5 +1,5 @@
 import { TrackedEvent } from '../../lib'
-import { camelCase } from 'lodash'
+import { get, camelCase } from 'lodash'
 import * as prettier from 'prettier'
 
 import {
@@ -83,7 +83,7 @@ export interface TrackMessage<PropertiesType> {
     AppsFlyer?: {
       appsFlyerId: string
     }
-    [key: string]: boolean | { [key: string]: string }
+    [key: string]: boolean | { [key: string]: string } | undefined
   }
 }`
 
@@ -244,7 +244,7 @@ export async function genTSDeclarations(
       $schema: rules.$schema || 'http://json-schema.org/draft-07/schema#',
       title: rules.title,
       description: rules.description,
-      ...rules.properties.properties
+      ...get(rules, 'properties.properties', {})
     }
 
     inputData.addSource(

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,3 @@
+declare module 'omit-deep-lodash'
+declare module 'sort-keys'
+declare module '@nucleartide/dx'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
 import * as omitDeep from 'omit-deep-lodash'
 import * as sortKeys from 'sort-keys'
-import { flow } from 'lodash'
+import { get, flow } from 'lodash'
 
 /**
  * Remove all instances of `required: []` from a JSON Schema.
@@ -10,7 +10,7 @@ import { flow } from 'lodash'
  *
  * Inspired by: https://softwareengineering.stackexchange.com/a/323670
  */
-function removeEmptyRequireds(obj: object) {
+function removeEmptyRequireds(obj: any) {
   for (const property in obj) {
     if (obj.hasOwnProperty(property)) {
       const value = obj[property]
@@ -36,11 +36,11 @@ function removeEmptyRequireds(obj: object) {
 export const preprocessRules = flow(
   // In JSON Schema Draft-04, required fields must have at least one element.
   // Therefore, we strip `required: []` from your rules so this error isn't surfaced.
-  rules => {
+  (rules: any) => {
     removeEmptyRequireds(rules)
     return rules
   },
   // Enforce a deterministic ordering to reduce verson control deltas.
-  rules => sortKeys(rules, { deep: true }),
-  rules => omitDeep(rules, 'id')
+  (rules: any) => sortKeys(rules, { deep: true }),
+  (rules: any) => omitDeep(rules, 'id')
 )

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -55,7 +55,7 @@ export interface TrackMessage<PropertiesType> {
     AppsFlyer?: {
       appsFlyerId: string;
     };
-    [key: string]: boolean | { [key: string]: string };
+    [key: string]: boolean | { [key: string]: string } | undefined;
   };
 }
 

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -43,7 +43,7 @@ export interface TrackMessage<PropertiesType> {
    * A dictionary of extra context to attach to the call.
    * https://segment.com/docs/spec/common/#context
    */
-  context?: Object;
+  context?: any;
   /**
    * A dictionary of destination names that the message should be sent to.
    * By default all destinations are enabled. 'All' is a special key that

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es6",
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noImplicitAny": false,
+    "strict": true,
+    "strictFunctionTypes": false,
     "moduleResolution": "node",
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
This PR fixes an issue seen by Typewriter-users where the optional types introduced in https://github.com/segmentio/typewriter/pull/39 cause `strictNullChecks` errors during builds:

```
integrations?: {
    All?: boolean
    AppsFlyer?: {
      appsFlyerId: string
    }
    // Adds `| undefined`
    [key: string]: boolean | { [key: string]: string } | undefined
}
```

```
#!/bin/bash -eo pipefail
yarn build
yarn run v1.6.0
$ make build
./node_modules/.bin/tsc && rsync -am --include='*.graphql' --include='*/' --exclude='*' src dist
src/lib/typewriter/generated/index.d.ts:54:5 - error TS2411: Property 'All' of type 'boolean | undefined' is not assignable to string index type 'boolean | { [key: string]: string; }'.

54     All?: boolean;
       ~~~

src/lib/typewriter/generated/index.d.ts:55:5 - error TS2411: Property 'AppsFlyer' of type '{ appsFlyerId: string; } | undefined' is not assignable to string index type 'boolean | { [key: string]: string; }'.

55     AppsFlyer?: {
       ~~~~~~~~~


Found 2 errors.
```

This PR also enables `strict` on this codebase.