### PR TITLE
fix: optional message parameter in JS clients

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -44,19 +44,19 @@ export default class Analytics {
   constructor(analytics: any);
 
   feedViewed(
-    message: FeedViewed,
+    message?: FeedViewed,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
 
   photoViewed(
-    message: PhotoViewed,
+    message?: PhotoViewed,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
 
   profileViewed(
-    message: ProfileViewed,
+    message?: ProfileViewed,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;

--- a/examples/gen-js/js/analytics/generated/index.js
+++ b/examples/gen-js/js/analytics/generated/index.js
@@ -18,7 +18,7 @@ export default class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  feedViewed(props, context) {
+  feedViewed(props = {}, context) {
     var validate = function(
       data,
       dataPath,
@@ -101,7 +101,7 @@ export default class Analytics {
     }
     this.analytics.track("Feed Viewed", props, genOptions(context));
   }
-  photoViewed(props, context) {
+  photoViewed(props = {}, context) {
     var validate = function(
       data,
       dataPath,
@@ -184,7 +184,7 @@ export default class Analytics {
     }
     this.analytics.track("Photo Viewed", props, genOptions(context));
   }
-  profileViewed(props, context) {
+  profileViewed(props = {}, context) {
     var validate = function(
       data,
       dataPath,

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -168,7 +168,7 @@ export default class Analytics {
   constructor(analytics: any);
 
   orderCompleted(
-    message: TrackMessage<OrderCompleted>,
+    message?: TrackMessage<OrderCompleted>,
     callback?: AnalyticsNodeCallback
   ): void;
 }

--- a/examples/gen-js/node/analytics/generated/index.js
+++ b/examples/gen-js/node/analytics/generated/index.js
@@ -19,7 +19,7 @@ class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  orderCompleted(message, callback) {
+  orderCompleted(message = {}, callback) {
     var validate = function(
       data,
       dataPath,

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -44,19 +44,19 @@ export default class Analytics {
   constructor(analytics: any);
 
   feedViewed(
-    message: FeedViewed,
+    message?: FeedViewed,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
 
   photoViewed(
-    message: PhotoViewed,
+    message?: PhotoViewed,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
 
   profileViewed(
-    message: ProfileViewed,
+    message?: ProfileViewed,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;

--- a/examples/gen-js/ts/analytics/generated/index.js
+++ b/examples/gen-js/ts/analytics/generated/index.js
@@ -18,7 +18,7 @@ export default class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  feedViewed(props, context) {
+  feedViewed(props = {}, context) {
     var validate = function(
       data,
       dataPath,
@@ -101,7 +101,7 @@ export default class Analytics {
     }
     this.analytics.track("Feed Viewed", props, genOptions(context));
   }
-  photoViewed(props, context) {
+  photoViewed(props = {}, context) {
     var validate = function(
       data,
       dataPath,
@@ -184,7 +184,7 @@ export default class Analytics {
     }
     this.analytics.track("Photo Viewed", props, genOptions(context));
   }
-  profileViewed(props, context) {
+  profileViewed(props = {}, context) {
     var validate = function(
       data,
       dataPath,

--- a/src/commands/gen-js/library.ts
+++ b/src/commands/gen-js/library.ts
@@ -61,11 +61,11 @@ export function genJS(
       let trackCall = ''
       let validateCall = ''
       if (client === Client.js) {
-        parameters = 'props, context'
+        parameters = 'props = {}, context'
         trackCall = `this.analytics.track('${name}', props, genOptions(context))`
         validateCall = 'validate({ properties: props })'
       } else if (client === Client.node) {
-        parameters = 'message, callback'
+        parameters = 'message = {}, callback'
         trackCall = `
         message = {
           ...message,

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -217,14 +217,14 @@ class AJSTSDeclarationsRenderer extends TypeScriptRenderer {
       if (this.ajsOptions.client === Client.js) {
         this.emitLine([
           camelCaseName,
-          '(message: ',
+          '(message?: ',
           this.sourceFor(t).source,
           ', options?: SegmentOptions, callback?: AnalyticsJSCallback): void'
         ])
       } else if (this.ajsOptions.client === Client.node) {
         this.emitLine([
           camelCaseName,
-          '(message: TrackMessage<',
+          '(message?: TrackMessage<',
           this.sourceFor(t).source,
           '>, callback?: AnalyticsNodeCallback): void'
         ])

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -217,7 +217,7 @@ class AJSTSDeclarationsRenderer extends TypeScriptRenderer {
       if (this.ajsOptions.client === Client.js) {
         this.emitLine([
           camelCaseName,
-          '(message?: ',
+          '(props?: ',
           this.sourceFor(t).source,
           ', options?: SegmentOptions, callback?: AnalyticsJSCallback): void'
         ])

--- a/tests/commands/gen-js/__snapshots__/index.amd.js
+++ b/tests/commands/gen-js/__snapshots__/index.amd.js
@@ -21,7 +21,7 @@ define(["require", "exports"], function(require, exports) {
       }
       this.analytics = analytics || { track: () => null };
     }
-    terribleEventName3(props, context) {
+    terribleEventName3(props = {}, context) {
       var validate = function(
         data,
         dataPath,
@@ -79,7 +79,7 @@ define(["require", "exports"], function(require, exports) {
         genOptions(context)
       );
     }
-    emptyEvent(props, context) {
+    emptyEvent(props = {}, context) {
       var validate = function(
         data,
         dataPath,
@@ -142,7 +142,7 @@ define(["require", "exports"], function(require, exports) {
       }
       this.analytics.track("Empty Event", props, genOptions(context));
     }
-    exampleEvent(props, context) {
+    exampleEvent(props = {}, context) {
       var pattern0 = new RegExp("FOO|BAR");
       var validate = function(
         data,
@@ -1020,7 +1020,7 @@ define(["require", "exports"], function(require, exports) {
       }
       this.analytics.track("Example Event", props, genOptions(context));
     }
-    draft04Event(props, context) {
+    draft04Event(props = {}, context) {
       var validate = function(
         data,
         dataPath,
@@ -1083,7 +1083,7 @@ define(["require", "exports"], function(require, exports) {
       }
       this.analytics.track("Draft-04 Event", props, genOptions(context));
     }
-    draft06Event(props, context) {
+    draft06Event(props = {}, context) {
       var validate = function(
         data,
         dataPath,

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -167,7 +167,7 @@ export default class Analytics {
   constructor(analytics: any);
 
   the42TerribleEventName3(
-    message: The42_TerribleEventName3,
+    message?: The42_TerribleEventName3,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
@@ -178,13 +178,13 @@ export default class Analytics {
    * Required object (empty) property
    */
   emptyEvent(
-    message: { [key: string]: any },
+    message?: { [key: string]: any },
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
 
   exampleEvent(
-    message: ExampleEvent,
+    message?: ExampleEvent,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
@@ -195,7 +195,7 @@ export default class Analytics {
    * Required object (empty) property
    */
   draft04Event(
-    message: { [key: string]: any },
+    message?: { [key: string]: any },
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
@@ -206,7 +206,7 @@ export default class Analytics {
    * Required object (empty) property
    */
   draft06Event(
-    message: { [key: string]: any },
+    message?: { [key: string]: any },
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -167,7 +167,7 @@ export default class Analytics {
   constructor(analytics: any);
 
   the42TerribleEventName3(
-    message?: The42_TerribleEventName3,
+    props?: The42_TerribleEventName3,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
@@ -178,13 +178,13 @@ export default class Analytics {
    * Required object (empty) property
    */
   emptyEvent(
-    message?: { [key: string]: any },
+    props?: { [key: string]: any },
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
 
   exampleEvent(
-    message?: ExampleEvent,
+    props?: ExampleEvent,
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
@@ -195,7 +195,7 @@ export default class Analytics {
    * Required object (empty) property
    */
   draft04Event(
-    message?: { [key: string]: any },
+    props?: { [key: string]: any },
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;
@@ -206,7 +206,7 @@ export default class Analytics {
    * Required object (empty) property
    */
   draft06Event(
-    message?: { [key: string]: any },
+    props?: { [key: string]: any },
     options?: SegmentOptions,
     callback?: AnalyticsJSCallback
   ): void;

--- a/tests/commands/gen-js/__snapshots__/index.es5.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.js
@@ -1,24 +1,52 @@
-const genOptions = (context = {}) => ({
-  context: {
-    ...context,
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.4"
-    }
+"use strict";
+var __assign =
+  (this && this.__assign) ||
+  function() {
+    __assign =
+      Object.assign ||
+      function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+var genOptions = function(context) {
+  if (context === void 0) {
+    context = {};
   }
-});
-export default class Analytics {
+  return {
+    context: __assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.4"
+      }
+    })
+  };
+};
+var Analytics = /** @class */ (function() {
   /**
    * Instantiate a wrapper around an analytics library instance
    * @param {Analytics} analytics - The analytics.js library to wrap
    */
-  constructor(analytics) {
+  function Analytics(analytics) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
-    this.analytics = analytics || { track: () => null };
+    this.analytics = analytics || {
+      track: function() {
+        return null;
+      }
+    };
   }
-  terribleEventName3(props = {}, context) {
+  Analytics.prototype.terribleEventName3 = function(props, context) {
+    if (props === void 0) {
+      props = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -75,8 +103,11 @@ export default class Analytics {
       props,
       genOptions(context)
     );
-  }
-  emptyEvent(props = {}, context) {
+  };
+  Analytics.prototype.emptyEvent = function(props, context) {
+    if (props === void 0) {
+      props = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -138,8 +169,11 @@ export default class Analytics {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Empty Event", props, genOptions(context));
-  }
-  exampleEvent(props = {}, context) {
+  };
+  Analytics.prototype.exampleEvent = function(props, context) {
+    if (props === void 0) {
+      props = {};
+    }
     var pattern0 = new RegExp("FOO|BAR");
     var validate = function(
       data,
@@ -977,8 +1011,11 @@ export default class Analytics {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Example Event", props, genOptions(context));
-  }
-  draft04Event(props = {}, context) {
+  };
+  Analytics.prototype.draft04Event = function(props, context) {
+    if (props === void 0) {
+      props = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -1040,8 +1077,11 @@ export default class Analytics {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Draft-04 Event", props, genOptions(context));
-  }
-  draft06Event(props = {}, context) {
+  };
+  Analytics.prototype.draft06Event = function(props, context) {
+    if (props === void 0) {
+      props = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -1103,5 +1143,7 @@ export default class Analytics {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
     this.analytics.track("Draft-06 Event", props, genOptions(context));
-  }
-}
+  };
+  return Analytics;
+})();
+exports.default = Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.es5.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.node.js
@@ -1,24 +1,52 @@
-const genOptions = (context = {}) => ({
-  context: {
-    ...context,
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.4"
-    }
+"use strict";
+var __assign =
+  (this && this.__assign) ||
+  function() {
+    __assign =
+      Object.assign ||
+      function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+          s = arguments[i];
+          for (var p in s)
+            if (Object.prototype.hasOwnProperty.call(s, p)) t[p] = s[p];
+        }
+        return t;
+      };
+    return __assign.apply(this, arguments);
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+var genOptions = function(context) {
+  if (context === void 0) {
+    context = {};
   }
-});
-export default class Analytics {
+  return {
+    context: __assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.4"
+      }
+    })
+  };
+};
+var Analytics = /** @class */ (function() {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics.js library to wrap
+   * @param {Analytics} analytics - The analytics-node library to wrap
    */
-  constructor(analytics) {
+  function Analytics(analytics) {
     if (!analytics) {
-      throw new Error("An instance of analytics.js must be provided");
+      throw new Error("An instance of analytics-node must be provided");
     }
-    this.analytics = analytics || { track: () => null };
+    this.analytics = analytics || {
+      track: function() {
+        return null;
+      }
+    };
   }
-  terribleEventName3(props = {}, context) {
+  Analytics.prototype.terribleEventName3 = function(message, callback) {
+    if (message === void 0) {
+      message = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -67,16 +95,18 @@ export default class Analytics {
       validate.errors = vErrors;
       return errors === 0;
     };
-    if (!validate({ properties: props })) {
+    if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track(
-      "42_--terrible==event++name~!3",
-      props,
-      genOptions(context)
-    );
-  }
-  emptyEvent(props = {}, context) {
+    message = __assign({}, message, genOptions(message.context), {
+      event: "42_--terrible==event++name~!3"
+    });
+    this.analytics.track(message, callback);
+  };
+  Analytics.prototype.emptyEvent = function(message, callback) {
+    if (message === void 0) {
+      message = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -134,12 +164,18 @@ export default class Analytics {
       validate.errors = vErrors;
       return errors === 0;
     };
-    if (!validate({ properties: props })) {
+    if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Empty Event", props, genOptions(context));
-  }
-  exampleEvent(props = {}, context) {
+    message = __assign({}, message, genOptions(message.context), {
+      event: "Empty Event"
+    });
+    this.analytics.track(message, callback);
+  };
+  Analytics.prototype.exampleEvent = function(message, callback) {
+    if (message === void 0) {
+      message = {};
+    }
     var pattern0 = new RegExp("FOO|BAR");
     var validate = function(
       data,
@@ -973,12 +1009,18 @@ export default class Analytics {
       validate.errors = vErrors;
       return errors === 0;
     };
-    if (!validate({ properties: props })) {
+    if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Example Event", props, genOptions(context));
-  }
-  draft04Event(props = {}, context) {
+    message = __assign({}, message, genOptions(message.context), {
+      event: "Example Event"
+    });
+    this.analytics.track(message, callback);
+  };
+  Analytics.prototype.draft04Event = function(message, callback) {
+    if (message === void 0) {
+      message = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -1036,12 +1078,18 @@ export default class Analytics {
       validate.errors = vErrors;
       return errors === 0;
     };
-    if (!validate({ properties: props })) {
+    if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-04 Event", props, genOptions(context));
-  }
-  draft06Event(props = {}, context) {
+    message = __assign({}, message, genOptions(message.context), {
+      event: "Draft-04 Event"
+    });
+    this.analytics.track(message, callback);
+  };
+  Analytics.prototype.draft06Event = function(message, callback) {
+    if (message === void 0) {
+      message = {};
+    }
     var validate = function(
       data,
       dataPath,
@@ -1099,9 +1147,14 @@ export default class Analytics {
       validate.errors = vErrors;
       return errors === 0;
     };
-    if (!validate({ properties: props })) {
+    if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-06 Event", props, genOptions(context));
-  }
-}
+    message = __assign({}, message, genOptions(message.context), {
+      event: "Draft-06 Event"
+    });
+    this.analytics.track(message, callback);
+  };
+  return Analytics;
+})();
+exports.default = Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -211,7 +211,7 @@ export default class Analytics {
   constructor(analytics: any);
 
   the42TerribleEventName3(
-    message: TrackMessage<The42_TerribleEventName3>,
+    message?: TrackMessage<The42_TerribleEventName3>,
     callback?: AnalyticsNodeCallback
   ): void;
 
@@ -221,12 +221,12 @@ export default class Analytics {
    * Required object (empty) property
    */
   emptyEvent(
-    message: TrackMessage<{ [key: string]: any }>,
+    message?: TrackMessage<{ [key: string]: any }>,
     callback?: AnalyticsNodeCallback
   ): void;
 
   exampleEvent(
-    message: TrackMessage<ExampleEvent>,
+    message?: TrackMessage<ExampleEvent>,
     callback?: AnalyticsNodeCallback
   ): void;
 
@@ -236,7 +236,7 @@ export default class Analytics {
    * Required object (empty) property
    */
   draft04Event(
-    message: TrackMessage<{ [key: string]: any }>,
+    message?: TrackMessage<{ [key: string]: any }>,
     callback?: AnalyticsNodeCallback
   ): void;
 
@@ -246,7 +246,7 @@ export default class Analytics {
    * Required object (empty) property
    */
   draft06Event(
-    message: TrackMessage<{ [key: string]: any }>,
+    message?: TrackMessage<{ [key: string]: any }>,
     callback?: AnalyticsNodeCallback
   ): void;
 }

--- a/tests/commands/gen-js/__snapshots__/index.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.node.js
@@ -19,7 +19,7 @@ class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  terribleEventName3(message, callback) {
+  terribleEventName3(message = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -76,7 +76,7 @@ class Analytics {
     });
     this.analytics.track(message, callback);
   }
-  emptyEvent(message, callback) {
+  emptyEvent(message = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -142,7 +142,7 @@ class Analytics {
     });
     this.analytics.track(message, callback);
   }
-  exampleEvent(message, callback) {
+  exampleEvent(message = {}, callback) {
     var pattern0 = new RegExp("FOO|BAR");
     var validate = function(
       data,
@@ -984,7 +984,7 @@ class Analytics {
     });
     this.analytics.track(message, callback);
   }
-  draft04Event(message, callback) {
+  draft04Event(message = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -1050,7 +1050,7 @@ class Analytics {
     });
     this.analytics.track(message, callback);
   }
-  draft06Event(message, callback) {
+  draft06Event(message = {}, callback) {
     var validate = function(
       data,
       dataPath,

--- a/tests/commands/gen-js/__snapshots__/index.prod.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.js
@@ -15,23 +15,23 @@ export default class Analytics {
   constructor(analytics) {
     this.analytics = analytics || { track: () => null };
   }
-  terribleEventName3(props, context) {
+  terribleEventName3(props = {}, context) {
     this.analytics.track(
       "42_--terrible==event++name~!3",
       props,
       genOptions(context)
     );
   }
-  emptyEvent(props, context) {
+  emptyEvent(props = {}, context) {
     this.analytics.track("Empty Event", props, genOptions(context));
   }
-  exampleEvent(props, context) {
+  exampleEvent(props = {}, context) {
     this.analytics.track("Example Event", props, genOptions(context));
   }
-  draft04Event(props, context) {
+  draft04Event(props = {}, context) {
     this.analytics.track("Draft-04 Event", props, genOptions(context));
   }
-  draft06Event(props, context) {
+  draft06Event(props = {}, context) {
     this.analytics.track("Draft-06 Event", props, genOptions(context));
   }
 }

--- a/tests/commands/gen-js/__snapshots__/index.prod.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.node.js
@@ -16,31 +16,31 @@ class Analytics {
   constructor(analytics) {
     this.analytics = analytics || { track: () => null };
   }
-  terribleEventName3(message, callback) {
+  terribleEventName3(message = {}, callback) {
     message = Object.assign({}, message, genOptions(message.context), {
       event: "42_--terrible==event++name~!3"
     });
     this.analytics.track(message, callback);
   }
-  emptyEvent(message, callback) {
+  emptyEvent(message = {}, callback) {
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Empty Event"
     });
     this.analytics.track(message, callback);
   }
-  exampleEvent(message, callback) {
+  exampleEvent(message = {}, callback) {
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Example Event"
     });
     this.analytics.track(message, callback);
   }
-  draft04Event(message, callback) {
+  draft04Event(message = {}, callback) {
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Draft-04 Event"
     });
     this.analytics.track(message, callback);
   }
-  draft06Event(message, callback) {
+  draft06Event(message = {}, callback) {
     message = Object.assign({}, message, genOptions(message.context), {
       event: "Draft-06 Event"
     });

--- a/tests/commands/gen-js/__snapshots__/index.system.js
+++ b/tests/commands/gen-js/__snapshots__/index.system.js
@@ -25,7 +25,7 @@ System.register([], function(exports_1, context_1) {
           }
           this.analytics = analytics || { track: () => null };
         }
-        terribleEventName3(props, context) {
+        terribleEventName3(props = {}, context) {
           var validate = function(
             data,
             dataPath,
@@ -87,7 +87,7 @@ System.register([], function(exports_1, context_1) {
             genOptions(context)
           );
         }
-        emptyEvent(props, context) {
+        emptyEvent(props = {}, context) {
           var validate = function(
             data,
             dataPath,
@@ -154,7 +154,7 @@ System.register([], function(exports_1, context_1) {
           }
           this.analytics.track("Empty Event", props, genOptions(context));
         }
-        exampleEvent(props, context) {
+        exampleEvent(props = {}, context) {
           var pattern0 = new RegExp("FOO|BAR");
           var validate = function(
             data,
@@ -1061,7 +1061,7 @@ System.register([], function(exports_1, context_1) {
           }
           this.analytics.track("Example Event", props, genOptions(context));
         }
-        draft04Event(props, context) {
+        draft04Event(props = {}, context) {
           var validate = function(
             data,
             dataPath,
@@ -1128,7 +1128,7 @@ System.register([], function(exports_1, context_1) {
           }
           this.analytics.track("Draft-04 Event", props, genOptions(context));
         }
-        draft06Event(props, context) {
+        draft06Event(props = {}, context) {
           var validate = function(
             data,
             dataPath,

--- a/tests/commands/gen-js/__snapshots__/index.umd.js
+++ b/tests/commands/gen-js/__snapshots__/index.umd.js
@@ -28,7 +28,7 @@
       }
       this.analytics = analytics || { track: () => null };
     }
-    terribleEventName3(props, context) {
+    terribleEventName3(props = {}, context) {
       var validate = function(
         data,
         dataPath,
@@ -86,7 +86,7 @@
         genOptions(context)
       );
     }
-    emptyEvent(props, context) {
+    emptyEvent(props = {}, context) {
       var validate = function(
         data,
         dataPath,
@@ -149,7 +149,7 @@
       }
       this.analytics.track("Empty Event", props, genOptions(context));
     }
-    exampleEvent(props, context) {
+    exampleEvent(props = {}, context) {
       var pattern0 = new RegExp("FOO|BAR");
       var validate = function(
         data,
@@ -1027,7 +1027,7 @@
       }
       this.analytics.track("Example Event", props, genOptions(context));
     }
-    draft04Event(props, context) {
+    draft04Event(props = {}, context) {
       var validate = function(
         data,
         dataPath,
@@ -1090,7 +1090,7 @@
       }
       this.analytics.track("Draft-04 Event", props, genOptions(context));
     }
-    draft06Event(props, context) {
+    draft06Event(props = {}, context) {
       var validate = function(
         data,
         dataPath,

--- a/tests/commands/gen-js/library.test.ts
+++ b/tests/commands/gen-js/library.test.ts
@@ -48,3 +48,17 @@ test('genJS - compiled output matches snapshot - no runtime validation (analytic
     'index.prod.node.js'
   )
 })
+
+test('genJS - compiled output matches snapshot - ES5', async () => {
+  await testSnapshotSingleFile(
+    events => genJS(events, ScriptTarget.ES5, ModuleKind.CommonJS, Client.js),
+    'index.es5.js'
+  )
+})
+
+test('genJS - compiled output matches snapshot - ES5 (analytics-node)', async () => {
+  await testSnapshotSingleFile(
+    events => genJS(events, ScriptTarget.ES5, ModuleKind.CommonJS, Client.node),
+    'index.es5.node.js'
+  )
+})


### PR DESCRIPTION
This makes `message` an optional parameter for auto-generated `track` calls, allowing you to make calls in `ts`-compiled files without passing in a message:

```
typewriter.fooBar()
```

instead of:

```
typewriter.fooBar({})
```

----

This also adds tests for ES5-transpiled clients (in this case, to validate that optional parameters were transpiled).