### PR TITLE
fix: location should be optional

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -26,7 +26,7 @@ export interface Context {
   };
   ip?: string;
   locale?: string;
-  location: {
+  location?: {
     city?: string;
     country?: string;
     latitude?: string;

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -26,7 +26,7 @@ export interface Context {
   };
   ip?: string;
   locale?: string;
-  location: {
+  location?: {
     city?: string;
     country?: string;
     latitude?: string;

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -26,7 +26,7 @@ export interface Context {
   };
   ip?: string;
   locale?: string;
-  location: {
+  location?: {
     city?: string;
     country?: string;
     latitude?: string;

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -54,7 +54,7 @@ export interface Context {
   }
   ip?: string
   locale?: string
-  location: {
+  location?: {
     city?: string
     country?: string
     latitude?: string

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -26,7 +26,7 @@ export interface Context {
   };
   ip?: string;
   locale?: string;
-  location: {
+  location?: {
     city?: string;
     country?: string;
     latitude?: string;

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -26,7 +26,7 @@ export interface Context {
   };
   ip?: string;
   locale?: string;
-  location: {
+  location?: {
     city?: string;
     country?: string;
     latitude?: string;


### PR DESCRIPTION
I meant for all context props to be optional, but missed the `?` for `location`.