### PR TITLE
fix: all SegmentOptions should be optional

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -79,7 +79,7 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: {
+  integrations?: {
     All?: boolean;
     AppsFlyer?: {
       appsFlyerId: string;
@@ -90,7 +90,7 @@ export interface SegmentOptions {
    * A dictionary of extra context to attach to the call.
    * https://segment.com/docs/spec/common/#context
    */
-  context: Context;
+  context?: Context;
 }
 
 export interface FeedViewed {

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -79,7 +79,7 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: {
+  integrations?: {
     All?: boolean;
     AppsFlyer?: {
       appsFlyerId: string;
@@ -90,7 +90,7 @@ export interface SegmentOptions {
    * A dictionary of extra context to attach to the call.
    * https://segment.com/docs/spec/common/#context
    */
-  context: Context;
+  context?: Context;
 }
 
 export interface FeedViewed {

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -169,7 +169,7 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: {
+  integrations?: {
     All?: boolean
     AppsFlyer?: {
       appsFlyerId: string
@@ -180,7 +180,7 @@ export interface SegmentOptions {
    * A dictionary of extra context to attach to the call.
    * https://segment.com/docs/spec/common/#context
    */
-  context: Context
+  context?: Context
 }`
 
 /** Target language for a.js TypeScript Declarations */

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -79,7 +79,7 @@ export interface SegmentOptions {
    * Selectivly filter destinations. By default all destinations are enabled.
    * https://segment.com/docs/sources/website/analytics.js/#selecting-destinations
    */
-  integrations: {
+  integrations?: {
     All?: boolean;
     AppsFlyer?: {
       appsFlyerId: string;
@@ -90,7 +90,7 @@ export interface SegmentOptions {
    * A dictionary of extra context to attach to the call.
    * https://segment.com/docs/spec/common/#context
    */
-  context: Context;
+  context?: Context;
 }
 
 export interface The42_TerribleEventName3 {


### PR DESCRIPTION
Turns out _all_ `SegmentOptions` properties should be optional. 😄 