### PR TITLE
fix: javascript clients accepted context rather than options

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.js
+++ b/examples/gen-js/js/analytics/generated/index.js
@@ -1,12 +1,3 @@
-const genOptions = (context = {}) => ({
-  context: {
-    ...context,
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  }
-});
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -18,7 +9,16 @@ export default class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  feedViewed(props = {}, context) {
+  addTypewriterContext(context = {}) {
+    return {
+      ...context,
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    };
+  }
+  feedViewed(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -99,9 +99,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Feed Viewed", props, genOptions(context));
+    this.analytics.track("Feed Viewed", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  photoViewed(props = {}, context) {
+  photoViewed(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -182,9 +185,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Photo Viewed", props, genOptions(context));
+    this.analytics.track("Photo Viewed", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  profileViewed(props = {}, context) {
+  profileViewed(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -265,6 +271,9 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Profile Viewed", props, genOptions(context));
+    this.analytics.track("Profile Viewed", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
 }

--- a/examples/gen-js/js/analytics/generated/index.js
+++ b/examples/gen-js/js/analytics/generated/index.js
@@ -18,7 +18,7 @@ export default class Analytics {
       }
     };
   }
-  feedViewed(props = {}, options) {
+  feedViewed(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -99,12 +99,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Feed Viewed", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Feed Viewed",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  photoViewed(props = {}, options) {
+  photoViewed(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -185,12 +190,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Photo Viewed", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Photo Viewed",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  profileViewed(props = {}, options) {
+  profileViewed(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -271,9 +281,14 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Profile Viewed", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Profile Viewed",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
 }

--- a/examples/gen-js/node/analytics/generated/index.js
+++ b/examples/gen-js/node/analytics/generated/index.js
@@ -1,13 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const genOptions = (context = {}) => ({
-  context: Object.assign({}, context, {
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  })
-});
 class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -18,6 +10,14 @@ class Analytics {
       throw new Error("An instance of analytics-node must be provided");
     }
     this.analytics = analytics || { track: () => null };
+  }
+  addTypewriterContext(context = {}) {
+    return Object.assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    });
   }
   orderCompleted(message = {}, callback) {
     var validate = function(
@@ -565,7 +565,8 @@ class Analytics {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Order Completed"
     });
     this.analytics.track(message, callback);

--- a/examples/gen-js/ts/analytics/generated/index.js
+++ b/examples/gen-js/ts/analytics/generated/index.js
@@ -1,12 +1,3 @@
-const genOptions = (context = {}) => ({
-  context: {
-    ...context,
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  }
-});
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -18,7 +9,16 @@ export default class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  feedViewed(props = {}, context) {
+  addTypewriterContext(context = {}) {
+    return {
+      ...context,
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    };
+  }
+  feedViewed(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -99,9 +99,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Feed Viewed", props, genOptions(context));
+    this.analytics.track("Feed Viewed", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  photoViewed(props = {}, context) {
+  photoViewed(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -182,9 +185,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Photo Viewed", props, genOptions(context));
+    this.analytics.track("Photo Viewed", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  profileViewed(props = {}, context) {
+  profileViewed(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -265,6 +271,9 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Profile Viewed", props, genOptions(context));
+    this.analytics.track("Profile Viewed", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
 }

--- a/examples/gen-js/ts/analytics/generated/index.js
+++ b/examples/gen-js/ts/analytics/generated/index.js
@@ -18,7 +18,7 @@ export default class Analytics {
       }
     };
   }
-  feedViewed(props = {}, options) {
+  feedViewed(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -99,12 +99,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Feed Viewed", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Feed Viewed",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  photoViewed(props = {}, options) {
+  photoViewed(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -185,12 +190,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Photo Viewed", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Photo Viewed",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  profileViewed(props = {}, options) {
+  profileViewed(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -271,9 +281,14 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Profile Viewed", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Profile Viewed",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
 }

--- a/src/commands/gen-js/library.ts
+++ b/src/commands/gen-js/library.ts
@@ -61,11 +61,11 @@ export function genJS(
       let trackCall = ''
       let validateCall = ''
       if (client === Client.js) {
-        parameters = 'props = {}, options'
+        parameters = 'props = {}, options = {}, callback'
         trackCall = `this.analytics.track('${name}', props, {
           ...options,
           context: this.addTypewriterContext(options.context)
-        })`
+        }, callback)`
         validateCall = 'validate({ properties: props })'
       } else if (client === Client.node) {
         parameters = 'message = {}, callback'

--- a/src/commands/gen-js/library.ts
+++ b/src/commands/gen-js/library.ts
@@ -29,16 +29,6 @@ export function genJS(
     throw new Error('An instance of ${clientName} must be provided')
   }`
   const fileHeader = `
-    const genOptions = (context = {}) => ({
-      context: {
-        ...context,
-        typewriter: {
-          name: "${command}",
-          version: "${version}"
-        }
-      }
-    })
-
     export default class Analytics {
       /**
        * Instantiate a wrapper around an analytics library instance
@@ -47,6 +37,16 @@ export function genJS(
       constructor(analytics) {
         ${runtimeValidation ? analyticsValidation : ''}
         this.analytics = analytics || { track: () => null }
+      }
+
+      addTypewriterContext(context = {}) {
+        return {
+          ...context,
+          typewriter: {
+            name: "${command}",
+            version: "${version}"
+          }
+        }
       }
   `
 
@@ -61,15 +61,18 @@ export function genJS(
       let trackCall = ''
       let validateCall = ''
       if (client === Client.js) {
-        parameters = 'props = {}, context'
-        trackCall = `this.analytics.track('${name}', props, genOptions(context))`
+        parameters = 'props = {}, options'
+        trackCall = `this.analytics.track('${name}', props, {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        })`
         validateCall = 'validate({ properties: props })'
       } else if (client === Client.node) {
         parameters = 'message = {}, callback'
         trackCall = `
         message = {
           ...message,
-          ...genOptions(message.context),
+          context: this.addTypewriterContext(message.context),
           event: '${name}'
         }
         this.analytics.track(message, callback)`

--- a/tests/commands/gen-js/__snapshots__/index.amd.js
+++ b/tests/commands/gen-js/__snapshots__/index.amd.js
@@ -1,15 +1,6 @@
 define(["require", "exports"], function(require, exports) {
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
-  const genOptions = (context = {}) => ({
-    context: {
-      ...context,
-      typewriter: {
-        name: "gen-js",
-        version: "5.1.7"
-      }
-    }
-  });
   class Analytics {
     /**
      * Instantiate a wrapper around an analytics library instance
@@ -21,7 +12,16 @@ define(["require", "exports"], function(require, exports) {
       }
       this.analytics = analytics || { track: () => null };
     }
-    terribleEventName3(props = {}, context) {
+    addTypewriterContext(context = {}) {
+      return {
+        ...context,
+        typewriter: {
+          name: "gen-js",
+          version: "5.1.7"
+        }
+      };
+    }
+    terribleEventName3(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -73,13 +73,12 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track(
-        "42_--terrible==event++name~!3",
-        props,
-        genOptions(context)
-      );
+      this.analytics.track("42_--terrible==event++name~!3", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    emptyEvent(props = {}, context) {
+    emptyEvent(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -140,9 +139,12 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Empty Event", props, genOptions(context));
+      this.analytics.track("Empty Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    exampleEvent(props = {}, context) {
+    exampleEvent(props = {}, options) {
       var pattern0 = new RegExp("FOO|BAR");
       var validate = function(
         data,
@@ -1018,9 +1020,12 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Example Event", props, genOptions(context));
+      this.analytics.track("Example Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    draft04Event(props = {}, context) {
+    draft04Event(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -1081,9 +1086,12 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-04 Event", props, genOptions(context));
+      this.analytics.track("Draft-04 Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    draft06Event(props = {}, context) {
+    draft06Event(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -1144,7 +1152,10 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-06 Event", props, genOptions(context));
+      this.analytics.track("Draft-06 Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
   }
   exports.default = Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.amd.js
+++ b/tests/commands/gen-js/__snapshots__/index.amd.js
@@ -21,7 +21,7 @@ define(["require", "exports"], function(require, exports) {
         }
       };
     }
-    terribleEventName3(props = {}, options) {
+    terribleEventName3(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -73,12 +73,17 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("42_--terrible==event++name~!3", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "42_--terrible==event++name~!3",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    emptyEvent(props = {}, options) {
+    emptyEvent(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -139,12 +144,17 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Empty Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Empty Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    exampleEvent(props = {}, options) {
+    exampleEvent(props = {}, options = {}, callback) {
       var pattern0 = new RegExp("FOO|BAR");
       var validate = function(
         data,
@@ -1020,12 +1030,17 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Example Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Example Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    draft04Event(props = {}, options) {
+    draft04Event(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -1086,12 +1101,17 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-04 Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Draft-04 Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    draft06Event(props = {}, options) {
+    draft06Event(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -1152,10 +1172,15 @@ define(["require", "exports"], function(require, exports) {
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-06 Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Draft-06 Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
   }
   exports.default = Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.es5.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.js
@@ -41,9 +41,12 @@ var Analytics = /** @class */ (function() {
       }
     });
   };
-  Analytics.prototype.terribleEventName3 = function(props, options) {
+  Analytics.prototype.terribleEventName3 = function(props, options, callback) {
     if (props === void 0) {
       props = {};
+    }
+    if (options === void 0) {
+      options = {};
     }
     var validate = function(
       data,
@@ -101,12 +104,16 @@ var Analytics = /** @class */ (function() {
       props,
       __assign({}, options, {
         context: this.addTypewriterContext(options.context)
-      })
+      }),
+      callback
     );
   };
-  Analytics.prototype.emptyEvent = function(props, options) {
+  Analytics.prototype.emptyEvent = function(props, options, callback) {
     if (props === void 0) {
       props = {};
+    }
+    if (options === void 0) {
+      options = {};
     }
     var validate = function(
       data,
@@ -173,12 +180,16 @@ var Analytics = /** @class */ (function() {
       props,
       __assign({}, options, {
         context: this.addTypewriterContext(options.context)
-      })
+      }),
+      callback
     );
   };
-  Analytics.prototype.exampleEvent = function(props, options) {
+  Analytics.prototype.exampleEvent = function(props, options, callback) {
     if (props === void 0) {
       props = {};
+    }
+    if (options === void 0) {
+      options = {};
     }
     var pattern0 = new RegExp("FOO|BAR");
     var validate = function(
@@ -1021,12 +1032,16 @@ var Analytics = /** @class */ (function() {
       props,
       __assign({}, options, {
         context: this.addTypewriterContext(options.context)
-      })
+      }),
+      callback
     );
   };
-  Analytics.prototype.draft04Event = function(props, options) {
+  Analytics.prototype.draft04Event = function(props, options, callback) {
     if (props === void 0) {
       props = {};
+    }
+    if (options === void 0) {
+      options = {};
     }
     var validate = function(
       data,
@@ -1093,12 +1108,16 @@ var Analytics = /** @class */ (function() {
       props,
       __assign({}, options, {
         context: this.addTypewriterContext(options.context)
-      })
+      }),
+      callback
     );
   };
-  Analytics.prototype.draft06Event = function(props, options) {
+  Analytics.prototype.draft06Event = function(props, options, callback) {
     if (props === void 0) {
       props = {};
+    }
+    if (options === void 0) {
+      options = {};
     }
     var validate = function(
       data,
@@ -1165,7 +1184,8 @@ var Analytics = /** @class */ (function() {
       props,
       __assign({}, options, {
         context: this.addTypewriterContext(options.context)
-      })
+      }),
+      callback
     );
   };
   return Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.es5.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.js
@@ -15,19 +15,6 @@ var __assign =
     return __assign.apply(this, arguments);
   };
 Object.defineProperty(exports, "__esModule", { value: true });
-var genOptions = function(context) {
-  if (context === void 0) {
-    context = {};
-  }
-  return {
-    context: __assign({}, context, {
-      typewriter: {
-        name: "gen-js",
-        version: "5.1.7"
-      }
-    })
-  };
-};
 var Analytics = /** @class */ (function() {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -43,7 +30,18 @@ var Analytics = /** @class */ (function() {
       }
     };
   }
-  Analytics.prototype.terribleEventName3 = function(props, context) {
+  Analytics.prototype.addTypewriterContext = function(context) {
+    if (context === void 0) {
+      context = {};
+    }
+    return __assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    });
+  };
+  Analytics.prototype.terribleEventName3 = function(props, options) {
     if (props === void 0) {
       props = {};
     }
@@ -101,10 +99,12 @@ var Analytics = /** @class */ (function() {
     this.analytics.track(
       "42_--terrible==event++name~!3",
       props,
-      genOptions(context)
+      __assign({}, options, {
+        context: this.addTypewriterContext(options.context)
+      })
     );
   };
-  Analytics.prototype.emptyEvent = function(props, context) {
+  Analytics.prototype.emptyEvent = function(props, options) {
     if (props === void 0) {
       props = {};
     }
@@ -168,9 +168,15 @@ var Analytics = /** @class */ (function() {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Empty Event", props, genOptions(context));
+    this.analytics.track(
+      "Empty Event",
+      props,
+      __assign({}, options, {
+        context: this.addTypewriterContext(options.context)
+      })
+    );
   };
-  Analytics.prototype.exampleEvent = function(props, context) {
+  Analytics.prototype.exampleEvent = function(props, options) {
     if (props === void 0) {
       props = {};
     }
@@ -1010,9 +1016,15 @@ var Analytics = /** @class */ (function() {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Example Event", props, genOptions(context));
+    this.analytics.track(
+      "Example Event",
+      props,
+      __assign({}, options, {
+        context: this.addTypewriterContext(options.context)
+      })
+    );
   };
-  Analytics.prototype.draft04Event = function(props, context) {
+  Analytics.prototype.draft04Event = function(props, options) {
     if (props === void 0) {
       props = {};
     }
@@ -1076,9 +1088,15 @@ var Analytics = /** @class */ (function() {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-04 Event", props, genOptions(context));
+    this.analytics.track(
+      "Draft-04 Event",
+      props,
+      __assign({}, options, {
+        context: this.addTypewriterContext(options.context)
+      })
+    );
   };
-  Analytics.prototype.draft06Event = function(props, context) {
+  Analytics.prototype.draft06Event = function(props, options) {
     if (props === void 0) {
       props = {};
     }
@@ -1142,7 +1160,13 @@ var Analytics = /** @class */ (function() {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-06 Event", props, genOptions(context));
+    this.analytics.track(
+      "Draft-06 Event",
+      props,
+      __assign({}, options, {
+        context: this.addTypewriterContext(options.context)
+      })
+    );
   };
   return Analytics;
 })();

--- a/tests/commands/gen-js/__snapshots__/index.es5.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.node.js
@@ -15,19 +15,6 @@ var __assign =
     return __assign.apply(this, arguments);
   };
 Object.defineProperty(exports, "__esModule", { value: true });
-var genOptions = function(context) {
-  if (context === void 0) {
-    context = {};
-  }
-  return {
-    context: __assign({}, context, {
-      typewriter: {
-        name: "gen-js",
-        version: "5.1.7"
-      }
-    })
-  };
-};
 var Analytics = /** @class */ (function() {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -43,6 +30,17 @@ var Analytics = /** @class */ (function() {
       }
     };
   }
+  Analytics.prototype.addTypewriterContext = function(context) {
+    if (context === void 0) {
+      context = {};
+    }
+    return __assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    });
+  };
   Analytics.prototype.terribleEventName3 = function(message, callback) {
     if (message === void 0) {
       message = {};
@@ -98,7 +96,8 @@ var Analytics = /** @class */ (function() {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = __assign({}, message, genOptions(message.context), {
+    message = __assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "42_--terrible==event++name~!3"
     });
     this.analytics.track(message, callback);
@@ -167,7 +166,8 @@ var Analytics = /** @class */ (function() {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = __assign({}, message, genOptions(message.context), {
+    message = __assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Empty Event"
     });
     this.analytics.track(message, callback);
@@ -1012,7 +1012,8 @@ var Analytics = /** @class */ (function() {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = __assign({}, message, genOptions(message.context), {
+    message = __assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Example Event"
     });
     this.analytics.track(message, callback);
@@ -1081,7 +1082,8 @@ var Analytics = /** @class */ (function() {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = __assign({}, message, genOptions(message.context), {
+    message = __assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Draft-04 Event"
     });
     this.analytics.track(message, callback);
@@ -1150,7 +1152,8 @@ var Analytics = /** @class */ (function() {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = __assign({}, message, genOptions(message.context), {
+    message = __assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Draft-06 Event"
     });
     this.analytics.track(message, callback);

--- a/tests/commands/gen-js/__snapshots__/index.js
+++ b/tests/commands/gen-js/__snapshots__/index.js
@@ -1,12 +1,3 @@
-const genOptions = (context = {}) => ({
-  context: {
-    ...context,
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  }
-});
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -18,7 +9,16 @@ export default class Analytics {
     }
     this.analytics = analytics || { track: () => null };
   }
-  terribleEventName3(props = {}, context) {
+  addTypewriterContext(context = {}) {
+    return {
+      ...context,
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    };
+  }
+  terribleEventName3(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -70,13 +70,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track(
-      "42_--terrible==event++name~!3",
-      props,
-      genOptions(context)
-    );
+    this.analytics.track("42_--terrible==event++name~!3", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  emptyEvent(props = {}, context) {
+  emptyEvent(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -137,9 +136,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Empty Event", props, genOptions(context));
+    this.analytics.track("Empty Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  exampleEvent(props = {}, context) {
+  exampleEvent(props = {}, options) {
     var pattern0 = new RegExp("FOO|BAR");
     var validate = function(
       data,
@@ -976,9 +978,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Example Event", props, genOptions(context));
+    this.analytics.track("Example Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  draft04Event(props = {}, context) {
+  draft04Event(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -1039,9 +1044,12 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-04 Event", props, genOptions(context));
+    this.analytics.track("Draft-04 Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  draft06Event(props = {}, context) {
+  draft06Event(props = {}, options) {
     var validate = function(
       data,
       dataPath,
@@ -1102,6 +1110,9 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-06 Event", props, genOptions(context));
+    this.analytics.track("Draft-06 Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
 }

--- a/tests/commands/gen-js/__snapshots__/index.js
+++ b/tests/commands/gen-js/__snapshots__/index.js
@@ -18,7 +18,7 @@ export default class Analytics {
       }
     };
   }
-  terribleEventName3(props = {}, options) {
+  terribleEventName3(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -70,12 +70,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("42_--terrible==event++name~!3", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "42_--terrible==event++name~!3",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  emptyEvent(props = {}, options) {
+  emptyEvent(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -136,12 +141,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Empty Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Empty Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  exampleEvent(props = {}, options) {
+  exampleEvent(props = {}, options = {}, callback) {
     var pattern0 = new RegExp("FOO|BAR");
     var validate = function(
       data,
@@ -978,12 +988,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Example Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Example Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  draft04Event(props = {}, options) {
+  draft04Event(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -1044,12 +1059,17 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-04 Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Draft-04 Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  draft06Event(props = {}, options) {
+  draft06Event(props = {}, options = {}, callback) {
     var validate = function(
       data,
       dataPath,
@@ -1110,9 +1130,14 @@ export default class Analytics {
     if (!validate({ properties: props })) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    this.analytics.track("Draft-06 Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+    this.analytics.track(
+      "Draft-06 Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
 }

--- a/tests/commands/gen-js/__snapshots__/index.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.node.js
@@ -1,13 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const genOptions = (context = {}) => ({
-  context: Object.assign({}, context, {
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  })
-});
 class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -18,6 +10,14 @@ class Analytics {
       throw new Error("An instance of analytics-node must be provided");
     }
     this.analytics = analytics || { track: () => null };
+  }
+  addTypewriterContext(context = {}) {
+    return Object.assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    });
   }
   terribleEventName3(message = {}, callback) {
     var validate = function(
@@ -71,7 +71,8 @@ class Analytics {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "42_--terrible==event++name~!3"
     });
     this.analytics.track(message, callback);
@@ -137,7 +138,8 @@ class Analytics {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Empty Event"
     });
     this.analytics.track(message, callback);
@@ -979,7 +981,8 @@ class Analytics {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Example Event"
     });
     this.analytics.track(message, callback);
@@ -1045,7 +1048,8 @@ class Analytics {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Draft-04 Event"
     });
     this.analytics.track(message, callback);
@@ -1111,7 +1115,8 @@ class Analytics {
     if (!validate(message)) {
       throw new Error(JSON.stringify(validate.errors, null, 2));
     }
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Draft-06 Event"
     });
     this.analytics.track(message, callback);

--- a/tests/commands/gen-js/__snapshots__/index.prod.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.js
@@ -15,34 +15,59 @@ export default class Analytics {
       }
     };
   }
-  terribleEventName3(props = {}, options) {
-    this.analytics.track("42_--terrible==event++name~!3", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+  terribleEventName3(props = {}, options = {}, callback) {
+    this.analytics.track(
+      "42_--terrible==event++name~!3",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  emptyEvent(props = {}, options) {
-    this.analytics.track("Empty Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+  emptyEvent(props = {}, options = {}, callback) {
+    this.analytics.track(
+      "Empty Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  exampleEvent(props = {}, options) {
-    this.analytics.track("Example Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+  exampleEvent(props = {}, options = {}, callback) {
+    this.analytics.track(
+      "Example Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  draft04Event(props = {}, options) {
-    this.analytics.track("Draft-04 Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+  draft04Event(props = {}, options = {}, callback) {
+    this.analytics.track(
+      "Draft-04 Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
-  draft06Event(props = {}, options) {
-    this.analytics.track("Draft-06 Event", props, {
-      ...options,
-      context: this.addTypewriterContext(options.context)
-    });
+  draft06Event(props = {}, options = {}, callback) {
+    this.analytics.track(
+      "Draft-06 Event",
+      props,
+      {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      },
+      callback
+    );
   }
 }

--- a/tests/commands/gen-js/__snapshots__/index.prod.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.js
@@ -1,12 +1,3 @@
-const genOptions = (context = {}) => ({
-  context: {
-    ...context,
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  }
-});
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -15,23 +6,43 @@ export default class Analytics {
   constructor(analytics) {
     this.analytics = analytics || { track: () => null };
   }
-  terribleEventName3(props = {}, context) {
-    this.analytics.track(
-      "42_--terrible==event++name~!3",
-      props,
-      genOptions(context)
-    );
+  addTypewriterContext(context = {}) {
+    return {
+      ...context,
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    };
   }
-  emptyEvent(props = {}, context) {
-    this.analytics.track("Empty Event", props, genOptions(context));
+  terribleEventName3(props = {}, options) {
+    this.analytics.track("42_--terrible==event++name~!3", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  exampleEvent(props = {}, context) {
-    this.analytics.track("Example Event", props, genOptions(context));
+  emptyEvent(props = {}, options) {
+    this.analytics.track("Empty Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  draft04Event(props = {}, context) {
-    this.analytics.track("Draft-04 Event", props, genOptions(context));
+  exampleEvent(props = {}, options) {
+    this.analytics.track("Example Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
-  draft06Event(props = {}, context) {
-    this.analytics.track("Draft-06 Event", props, genOptions(context));
+  draft04Event(props = {}, options) {
+    this.analytics.track("Draft-04 Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
+  }
+  draft06Event(props = {}, options) {
+    this.analytics.track("Draft-06 Event", props, {
+      ...options,
+      context: this.addTypewriterContext(options.context)
+    });
   }
 }

--- a/tests/commands/gen-js/__snapshots__/index.prod.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.node.js
@@ -1,13 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const genOptions = (context = {}) => ({
-  context: Object.assign({}, context, {
-    typewriter: {
-      name: "gen-js",
-      version: "5.1.7"
-    }
-  })
-});
 class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
@@ -16,32 +8,45 @@ class Analytics {
   constructor(analytics) {
     this.analytics = analytics || { track: () => null };
   }
+  addTypewriterContext(context = {}) {
+    return Object.assign({}, context, {
+      typewriter: {
+        name: "gen-js",
+        version: "5.1.7"
+      }
+    });
+  }
   terribleEventName3(message = {}, callback) {
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "42_--terrible==event++name~!3"
     });
     this.analytics.track(message, callback);
   }
   emptyEvent(message = {}, callback) {
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Empty Event"
     });
     this.analytics.track(message, callback);
   }
   exampleEvent(message = {}, callback) {
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Example Event"
     });
     this.analytics.track(message, callback);
   }
   draft04Event(message = {}, callback) {
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Draft-04 Event"
     });
     this.analytics.track(message, callback);
   }
   draft06Event(message = {}, callback) {
-    message = Object.assign({}, message, genOptions(message.context), {
+    message = Object.assign({}, message, {
+      context: this.addTypewriterContext(message.context),
       event: "Draft-06 Event"
     });
     this.analytics.track(message, callback);

--- a/tests/commands/gen-js/__snapshots__/index.system.js
+++ b/tests/commands/gen-js/__snapshots__/index.system.js
@@ -25,7 +25,7 @@ System.register([], function(exports_1, context_1) {
             }
           };
         }
-        terribleEventName3(props = {}, options) {
+        terribleEventName3(props = {}, options = {}, callback) {
           var validate = function(
             data,
             dataPath,
@@ -81,12 +81,17 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("42_--terrible==event++name~!3", props, {
-            ...options,
-            context: this.addTypewriterContext(options.context)
-          });
+          this.analytics.track(
+            "42_--terrible==event++name~!3",
+            props,
+            {
+              ...options,
+              context: this.addTypewriterContext(options.context)
+            },
+            callback
+          );
         }
-        emptyEvent(props = {}, options) {
+        emptyEvent(props = {}, options = {}, callback) {
           var validate = function(
             data,
             dataPath,
@@ -151,12 +156,17 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Empty Event", props, {
-            ...options,
-            context: this.addTypewriterContext(options.context)
-          });
+          this.analytics.track(
+            "Empty Event",
+            props,
+            {
+              ...options,
+              context: this.addTypewriterContext(options.context)
+            },
+            callback
+          );
         }
-        exampleEvent(props = {}, options) {
+        exampleEvent(props = {}, options = {}, callback) {
           var pattern0 = new RegExp("FOO|BAR");
           var validate = function(
             data,
@@ -1061,12 +1071,17 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Example Event", props, {
-            ...options,
-            context: this.addTypewriterContext(options.context)
-          });
+          this.analytics.track(
+            "Example Event",
+            props,
+            {
+              ...options,
+              context: this.addTypewriterContext(options.context)
+            },
+            callback
+          );
         }
-        draft04Event(props = {}, options) {
+        draft04Event(props = {}, options = {}, callback) {
           var validate = function(
             data,
             dataPath,
@@ -1131,12 +1146,17 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Draft-04 Event", props, {
-            ...options,
-            context: this.addTypewriterContext(options.context)
-          });
+          this.analytics.track(
+            "Draft-04 Event",
+            props,
+            {
+              ...options,
+              context: this.addTypewriterContext(options.context)
+            },
+            callback
+          );
         }
-        draft06Event(props = {}, options) {
+        draft06Event(props = {}, options = {}, callback) {
           var validate = function(
             data,
             dataPath,
@@ -1201,10 +1221,15 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Draft-06 Event", props, {
-            ...options,
-            context: this.addTypewriterContext(options.context)
-          });
+          this.analytics.track(
+            "Draft-06 Event",
+            props,
+            {
+              ...options,
+              context: this.addTypewriterContext(options.context)
+            },
+            callback
+          );
         }
       };
       exports_1("default", Analytics);

--- a/tests/commands/gen-js/__snapshots__/index.system.js
+++ b/tests/commands/gen-js/__snapshots__/index.system.js
@@ -1,19 +1,10 @@
 System.register([], function(exports_1, context_1) {
   "use strict";
-  var genOptions, Analytics;
+  var Analytics;
   var __moduleName = context_1 && context_1.id;
   return {
     setters: [],
     execute: function() {
-      genOptions = (context = {}) => ({
-        context: {
-          ...context,
-          typewriter: {
-            name: "gen-js",
-            version: "5.1.7"
-          }
-        }
-      });
       Analytics = class Analytics {
         /**
          * Instantiate a wrapper around an analytics library instance
@@ -25,7 +16,16 @@ System.register([], function(exports_1, context_1) {
           }
           this.analytics = analytics || { track: () => null };
         }
-        terribleEventName3(props = {}, context) {
+        addTypewriterContext(context = {}) {
+          return {
+            ...context,
+            typewriter: {
+              name: "gen-js",
+              version: "5.1.7"
+            }
+          };
+        }
+        terribleEventName3(props = {}, options) {
           var validate = function(
             data,
             dataPath,
@@ -81,13 +81,12 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track(
-            "42_--terrible==event++name~!3",
-            props,
-            genOptions(context)
-          );
+          this.analytics.track("42_--terrible==event++name~!3", props, {
+            ...options,
+            context: this.addTypewriterContext(options.context)
+          });
         }
-        emptyEvent(props = {}, context) {
+        emptyEvent(props = {}, options) {
           var validate = function(
             data,
             dataPath,
@@ -152,9 +151,12 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Empty Event", props, genOptions(context));
+          this.analytics.track("Empty Event", props, {
+            ...options,
+            context: this.addTypewriterContext(options.context)
+          });
         }
-        exampleEvent(props = {}, context) {
+        exampleEvent(props = {}, options) {
           var pattern0 = new RegExp("FOO|BAR");
           var validate = function(
             data,
@@ -1059,9 +1061,12 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Example Event", props, genOptions(context));
+          this.analytics.track("Example Event", props, {
+            ...options,
+            context: this.addTypewriterContext(options.context)
+          });
         }
-        draft04Event(props = {}, context) {
+        draft04Event(props = {}, options) {
           var validate = function(
             data,
             dataPath,
@@ -1126,9 +1131,12 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Draft-04 Event", props, genOptions(context));
+          this.analytics.track("Draft-04 Event", props, {
+            ...options,
+            context: this.addTypewriterContext(options.context)
+          });
         }
-        draft06Event(props = {}, context) {
+        draft06Event(props = {}, options) {
           var validate = function(
             data,
             dataPath,
@@ -1193,7 +1201,10 @@ System.register([], function(exports_1, context_1) {
           if (!validate({ properties: props })) {
             throw new Error(JSON.stringify(validate.errors, null, 2));
           }
-          this.analytics.track("Draft-06 Event", props, genOptions(context));
+          this.analytics.track("Draft-06 Event", props, {
+            ...options,
+            context: this.addTypewriterContext(options.context)
+          });
         }
       };
       exports_1("default", Analytics);

--- a/tests/commands/gen-js/__snapshots__/index.umd.js
+++ b/tests/commands/gen-js/__snapshots__/index.umd.js
@@ -8,15 +8,6 @@
 })(function(require, exports) {
   "use strict";
   Object.defineProperty(exports, "__esModule", { value: true });
-  const genOptions = (context = {}) => ({
-    context: {
-      ...context,
-      typewriter: {
-        name: "gen-js",
-        version: "5.1.7"
-      }
-    }
-  });
   class Analytics {
     /**
      * Instantiate a wrapper around an analytics library instance
@@ -28,7 +19,16 @@
       }
       this.analytics = analytics || { track: () => null };
     }
-    terribleEventName3(props = {}, context) {
+    addTypewriterContext(context = {}) {
+      return {
+        ...context,
+        typewriter: {
+          name: "gen-js",
+          version: "5.1.7"
+        }
+      };
+    }
+    terribleEventName3(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -80,13 +80,12 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track(
-        "42_--terrible==event++name~!3",
-        props,
-        genOptions(context)
-      );
+      this.analytics.track("42_--terrible==event++name~!3", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    emptyEvent(props = {}, context) {
+    emptyEvent(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -147,9 +146,12 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Empty Event", props, genOptions(context));
+      this.analytics.track("Empty Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    exampleEvent(props = {}, context) {
+    exampleEvent(props = {}, options) {
       var pattern0 = new RegExp("FOO|BAR");
       var validate = function(
         data,
@@ -1025,9 +1027,12 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Example Event", props, genOptions(context));
+      this.analytics.track("Example Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    draft04Event(props = {}, context) {
+    draft04Event(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -1088,9 +1093,12 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-04 Event", props, genOptions(context));
+      this.analytics.track("Draft-04 Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
-    draft06Event(props = {}, context) {
+    draft06Event(props = {}, options) {
       var validate = function(
         data,
         dataPath,
@@ -1151,7 +1159,10 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-06 Event", props, genOptions(context));
+      this.analytics.track("Draft-06 Event", props, {
+        ...options,
+        context: this.addTypewriterContext(options.context)
+      });
     }
   }
   exports.default = Analytics;

--- a/tests/commands/gen-js/__snapshots__/index.umd.js
+++ b/tests/commands/gen-js/__snapshots__/index.umd.js
@@ -28,7 +28,7 @@
         }
       };
     }
-    terribleEventName3(props = {}, options) {
+    terribleEventName3(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -80,12 +80,17 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("42_--terrible==event++name~!3", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "42_--terrible==event++name~!3",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    emptyEvent(props = {}, options) {
+    emptyEvent(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -146,12 +151,17 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Empty Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Empty Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    exampleEvent(props = {}, options) {
+    exampleEvent(props = {}, options = {}, callback) {
       var pattern0 = new RegExp("FOO|BAR");
       var validate = function(
         data,
@@ -1027,12 +1037,17 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Example Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Example Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    draft04Event(props = {}, options) {
+    draft04Event(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -1093,12 +1108,17 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-04 Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Draft-04 Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
-    draft06Event(props = {}, options) {
+    draft06Event(props = {}, options = {}, callback) {
       var validate = function(
         data,
         dataPath,
@@ -1159,10 +1179,15 @@
       if (!validate({ properties: props })) {
         throw new Error(JSON.stringify(validate.errors, null, 2));
       }
-      this.analytics.track("Draft-06 Event", props, {
-        ...options,
-        context: this.addTypewriterContext(options.context)
-      });
+      this.analytics.track(
+        "Draft-06 Event",
+        props,
+        {
+          ...options,
+          context: this.addTypewriterContext(options.context)
+        },
+        callback
+      );
     }
   }
   exports.default = Analytics;


### PR DESCRIPTION
BREAKING CHANGE: if you previously passed `context` directly as the final
  parameter to the `analytics.js` or `analytics-node` clients, then you'll
  need to update it, like so:

  If you made a call like:

  ```
  typewriter.thingHappened({ when: 'now' }, { groupId: 123 })
  ```

  Then you would need to update it to:

  ```
  typewriter.thingHappened({ when: 'now' }, {
    context: { groupId: 123 }
  })
  ```

  This allows you to pass `integrations` and other fields in through this
  object, and aligns the TypeScript declarations with the underlying library.