### PR TITLE
feat: custom error handlers

### DIFF
--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -118,23 +118,30 @@ export interface ProfileViewed {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
-interface AnalyticsOptions {
-  onError: (
-    error: {
-      eventName: string;
-      validationErrors: Array<{
-        keyword: string;
-        dataPath: string;
-        schemaPath: string;
-        params: object;
-        message: string;
-        propertyName?: string;
-        parentSchema?: object;
-        data?: any;
-      }>;
-    }
-  ) => void;
+
+// From https://github.com/epoberezkin/ajv/blob/0c31c1e2a81e315511c60a0dd7420a72cb181e61/lib/ajv.d.ts#L279
+interface AjvErrorObject {
+  keyword: string;
+  dataPath: string;
+  schemaPath: string;
+  params: object;
+  message: string;
+  propertyName?: string;
+  parentSchema?: object;
+  data?: any;
 }
+
+// An invalid event with its associated collection of validation errors.
+interface InvalidEvent {
+  eventName: string;
+  validationErrors: AjvErrorObject[];
+}
+
+// Options to customize the runtime behavior of a Typewriter client.
+interface AnalyticsOptions {
+  onError(event: InvalidEvent): void;
+}
+
 export default class Analytics {
   constructor(analytics: any, options?: AnalyticsOptions);
 

--- a/examples/gen-js/js/analytics/generated/index.d.ts
+++ b/examples/gen-js/js/analytics/generated/index.d.ts
@@ -118,8 +118,25 @@ export interface ProfileViewed {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
+interface AnalyticsOptions {
+  onError: (
+    error: {
+      eventName: string;
+      validationErrors: Array<{
+        keyword: string;
+        dataPath: string;
+        schemaPath: string;
+        params: object;
+        message: string;
+        propertyName?: string;
+        parentSchema?: object;
+        data?: any;
+      }>;
+    }
+  ) => void;
+}
 export default class Analytics {
-  constructor(analytics: any);
+  constructor(analytics: any, options?: AnalyticsOptions);
 
   feedViewed(
     props?: FeedViewed,

--- a/examples/gen-js/js/analytics/generated/index.js
+++ b/examples/gen-js/js/analytics/generated/index.js
@@ -1,13 +1,21 @@
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics.js library to wrap
+   * @param {Analytics} analytics The analytics.js library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (error => {
+        throw new Error(JSON.stringify(error, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return {
@@ -97,7 +105,11 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Feed Viewed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     this.analytics.track(
       "Feed Viewed",
@@ -188,7 +200,11 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Photo Viewed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     this.analytics.track(
       "Photo Viewed",
@@ -279,7 +295,11 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Profile Viewed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     this.analytics.track(
       "Profile Viewed",

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -237,23 +237,30 @@ export interface Product {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
-interface AnalyticsOptions {
-  onError: (
-    error: {
-      eventName: string;
-      validationErrors: Array<{
-        keyword: string;
-        dataPath: string;
-        schemaPath: string;
-        params: object;
-        message: string;
-        propertyName?: string;
-        parentSchema?: object;
-        data?: any;
-      }>;
-    }
-  ) => void;
+
+// From https://github.com/epoberezkin/ajv/blob/0c31c1e2a81e315511c60a0dd7420a72cb181e61/lib/ajv.d.ts#L279
+interface AjvErrorObject {
+  keyword: string;
+  dataPath: string;
+  schemaPath: string;
+  params: object;
+  message: string;
+  propertyName?: string;
+  parentSchema?: object;
+  data?: any;
 }
+
+// An invalid event with its associated collection of validation errors.
+interface InvalidEvent {
+  eventName: string;
+  validationErrors: AjvErrorObject[];
+}
+
+// Options to customize the runtime behavior of a Typewriter client.
+interface AnalyticsOptions {
+  onError(event: InvalidEvent): void;
+}
+
 export default class Analytics {
   constructor(analytics: any, options?: AnalyticsOptions);
 

--- a/examples/gen-js/node/analytics/generated/index.d.ts
+++ b/examples/gen-js/node/analytics/generated/index.d.ts
@@ -237,8 +237,25 @@ export interface Product {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
+interface AnalyticsOptions {
+  onError: (
+    error: {
+      eventName: string;
+      validationErrors: Array<{
+        keyword: string;
+        dataPath: string;
+        schemaPath: string;
+        params: object;
+        message: string;
+        propertyName?: string;
+        parentSchema?: object;
+        data?: any;
+      }>;
+    }
+  ) => void;
+}
 export default class Analytics {
-  constructor(analytics: any);
+  constructor(analytics: any, options?: AnalyticsOptions);
 
   orderCompleted(
     message?: TrackMessage<OrderCompleted>,

--- a/examples/gen-js/node/analytics/generated/index.js
+++ b/examples/gen-js/node/analytics/generated/index.js
@@ -3,13 +3,21 @@ Object.defineProperty(exports, "__esModule", { value: true });
 class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics-node library to wrap
+   * @param {Analytics} analytics The analytics-node library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     if (!analytics) {
       throw new Error("An instance of analytics-node must be provided");
     }
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (error => {
+        throw new Error(JSON.stringify(error, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return Object.assign({}, context, {
@@ -563,7 +571,11 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Order Completed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     message = Object.assign({}, message, {
       context: this.addTypewriterContext(message.context),

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -118,23 +118,30 @@ export interface ProfileViewed {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
-interface AnalyticsOptions {
-  onError: (
-    error: {
-      eventName: string;
-      validationErrors: Array<{
-        keyword: string;
-        dataPath: string;
-        schemaPath: string;
-        params: object;
-        message: string;
-        propertyName?: string;
-        parentSchema?: object;
-        data?: any;
-      }>;
-    }
-  ) => void;
+
+// From https://github.com/epoberezkin/ajv/blob/0c31c1e2a81e315511c60a0dd7420a72cb181e61/lib/ajv.d.ts#L279
+interface AjvErrorObject {
+  keyword: string;
+  dataPath: string;
+  schemaPath: string;
+  params: object;
+  message: string;
+  propertyName?: string;
+  parentSchema?: object;
+  data?: any;
 }
+
+// An invalid event with its associated collection of validation errors.
+interface InvalidEvent {
+  eventName: string;
+  validationErrors: AjvErrorObject[];
+}
+
+// Options to customize the runtime behavior of a Typewriter client.
+interface AnalyticsOptions {
+  onError(event: InvalidEvent): void;
+}
+
 export default class Analytics {
   constructor(analytics: any, options?: AnalyticsOptions);
 

--- a/examples/gen-js/ts/analytics/generated/index.d.ts
+++ b/examples/gen-js/ts/analytics/generated/index.d.ts
@@ -118,8 +118,25 @@ export interface ProfileViewed {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
+interface AnalyticsOptions {
+  onError: (
+    error: {
+      eventName: string;
+      validationErrors: Array<{
+        keyword: string;
+        dataPath: string;
+        schemaPath: string;
+        params: object;
+        message: string;
+        propertyName?: string;
+        parentSchema?: object;
+        data?: any;
+      }>;
+    }
+  ) => void;
+}
 export default class Analytics {
-  constructor(analytics: any);
+  constructor(analytics: any, options?: AnalyticsOptions);
 
   feedViewed(
     props?: FeedViewed,

--- a/examples/gen-js/ts/analytics/generated/index.js
+++ b/examples/gen-js/ts/analytics/generated/index.js
@@ -1,13 +1,21 @@
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics.js library to wrap
+   * @param {Analytics} analytics The analytics.js library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (error => {
+        throw new Error(JSON.stringify(error, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return {
@@ -97,7 +105,11 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Feed Viewed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     this.analytics.track(
       "Feed Viewed",
@@ -188,7 +200,11 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Photo Viewed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     this.analytics.track(
       "Photo Viewed",
@@ -279,7 +295,11 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError({
+        eventName: "Profile Viewed",
+        validationErrors: validate.errors
+      });
+      return;
     }
     this.analytics.track(
       "Profile Viewed",

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -283,21 +283,30 @@ class AJSTSDeclarationsRenderer extends TypeScriptRenderer {
       'Analytics provides a strongly-typed wrapper around Segment Analytics',
       'based on your Tracking Plan.'
     ])
-    this.emitLine(`interface AnalyticsOptions {
-      onError: (error: {
-        eventName: string
-        validationErrors: Array<{
-          keyword: string
-          dataPath: string
-          schemaPath: string
-          params: object
-          message: string
-          propertyName?: string
-          parentSchema?: object
-          data?: any
-        }>
-      }) => void
-    }`)
+    this.emitLine(`
+      // From https://github.com/epoberezkin/ajv/blob/0c31c1e2a81e315511c60a0dd7420a72cb181e61/lib/ajv.d.ts#L279
+      interface AjvErrorObject {
+        keyword: string;
+        dataPath: string;
+        schemaPath: string;
+        params: object;
+        message: string;
+        propertyName?: string;
+        parentSchema?: object;
+        data?: any;
+      }
+
+      // An invalid event with its associated collection of validation errors.
+      interface InvalidEvent {
+        eventName: string;
+        validationErrors: AjvErrorObject[];
+      }
+
+      // Options to customize the runtime behavior of a Typewriter client.
+      interface AnalyticsOptions {
+        onError(event: InvalidEvent): void;
+      }
+    `)
     this.emitBlock('export default class Analytics', '', () => {
       this.emitLine('constructor(analytics: any, options?: AnalyticsOptions)')
       this.ensureBlankLine()

--- a/src/commands/gen-js/typescript.ts
+++ b/src/commands/gen-js/typescript.ts
@@ -283,8 +283,23 @@ class AJSTSDeclarationsRenderer extends TypeScriptRenderer {
       'Analytics provides a strongly-typed wrapper around Segment Analytics',
       'based on your Tracking Plan.'
     ])
+    this.emitLine(`interface AnalyticsOptions {
+      onError: (error: {
+        eventName: string
+        validationErrors: Array<{
+          keyword: string
+          dataPath: string
+          schemaPath: string
+          params: object
+          message: string
+          propertyName?: string
+          parentSchema?: object
+          data?: any
+        }>
+      }) => void
+    }`)
     this.emitBlock('export default class Analytics', '', () => {
-      this.emitLine('constructor(analytics: any)')
+      this.emitLine('constructor(analytics: any, options?: AnalyticsOptions)')
       this.ensureBlankLine()
 
       this.emitAnalyticsFunctions()

--- a/tests/commands/gen-js/__snapshots__/index.amd.js
+++ b/tests/commands/gen-js/__snapshots__/index.amd.js
@@ -16,8 +16,8 @@ define(["require", "exports"], function(require, exports) {
       this.analytics = analytics || { track: () => null };
       this.onError =
         options.onError ||
-        (() => {
-          throw new Error(JSON.stringify(errors, null, 2));
+        (error => {
+          throw new Error(JSON.stringify(error, null, 2));
         });
     }
     addTypewriterContext(context = {}) {
@@ -79,7 +79,10 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "42_--terrible==event++name~!3",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -151,7 +154,10 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Empty Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -1038,7 +1044,10 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Example Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -1110,7 +1119,10 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Draft-04 Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -1182,7 +1194,10 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Draft-06 Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(

--- a/tests/commands/gen-js/__snapshots__/index.amd.js
+++ b/tests/commands/gen-js/__snapshots__/index.amd.js
@@ -4,13 +4,21 @@ define(["require", "exports"], function(require, exports) {
   class Analytics {
     /**
      * Instantiate a wrapper around an analytics library instance
-     * @param {Analytics} analytics - The analytics.js library to wrap
+     * @param {Analytics} analytics The analytics.js library to wrap
+     * @param {Object} [options] Optional configuration of the Typewriter client
+     * @param {function} [options.onError] Error handler fired when run-time validation errors
+     *     are raised.
      */
-    constructor(analytics) {
+    constructor(analytics, options = {}) {
       if (!analytics) {
         throw new Error("An instance of analytics.js must be provided");
       }
       this.analytics = analytics || { track: () => null };
+      this.onError =
+        options.onError ||
+        (() => {
+          throw new Error(JSON.stringify(errors, null, 2));
+        });
     }
     addTypewriterContext(context = {}) {
       return {
@@ -71,7 +79,8 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "42_--terrible==event++name~!3",
@@ -142,7 +151,8 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Empty Event",
@@ -1028,7 +1038,8 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Example Event",
@@ -1099,7 +1110,8 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Draft-04 Event",
@@ -1170,7 +1182,8 @@ define(["require", "exports"], function(require, exports) {
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Draft-06 Event",

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -241,23 +241,30 @@ export interface RequiredObject {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
-interface AnalyticsOptions {
-  onError: (
-    error: {
-      eventName: string;
-      validationErrors: Array<{
-        keyword: string;
-        dataPath: string;
-        schemaPath: string;
-        params: object;
-        message: string;
-        propertyName?: string;
-        parentSchema?: object;
-        data?: any;
-      }>;
-    }
-  ) => void;
+
+// From https://github.com/epoberezkin/ajv/blob/0c31c1e2a81e315511c60a0dd7420a72cb181e61/lib/ajv.d.ts#L279
+interface AjvErrorObject {
+  keyword: string;
+  dataPath: string;
+  schemaPath: string;
+  params: object;
+  message: string;
+  propertyName?: string;
+  parentSchema?: object;
+  data?: any;
 }
+
+// An invalid event with its associated collection of validation errors.
+interface InvalidEvent {
+  eventName: string;
+  validationErrors: AjvErrorObject[];
+}
+
+// Options to customize the runtime behavior of a Typewriter client.
+interface AnalyticsOptions {
+  onError(event: InvalidEvent): void;
+}
+
 export default class Analytics {
   constructor(analytics: any, options?: AnalyticsOptions);
 

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -241,8 +241,25 @@ export interface RequiredObject {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
+interface AnalyticsOptions {
+  onError: (
+    error: {
+      eventName: string;
+      validationErrors: Array<{
+        keyword: string;
+        dataPath: string;
+        schemaPath: string;
+        params: object;
+        message: string;
+        propertyName?: string;
+        parentSchema?: object;
+        data?: any;
+      }>;
+    }
+  ) => void;
+}
 export default class Analytics {
-  constructor(analytics: any, options: { onError: (errors: object) => void });
+  constructor(analytics: any, options?: AnalyticsOptions);
 
   the42TerribleEventName3(
     props?: The42_TerribleEventName3,

--- a/tests/commands/gen-js/__snapshots__/index.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.d.ts
@@ -242,7 +242,7 @@ export interface RequiredObject {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any);
+  constructor(analytics: any, options: { onError: (errors: object) => void });
 
   the42TerribleEventName3(
     props?: The42_TerribleEventName3,

--- a/tests/commands/gen-js/__snapshots__/index.es5.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.js
@@ -18,9 +18,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var Analytics = /** @class */ (function() {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics.js library to wrap
+   * @param {Analytics} analytics The analytics.js library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  function Analytics(analytics) {
+  function Analytics(analytics, options) {
+    if (options === void 0) {
+      options = {};
+    }
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
@@ -29,6 +35,11 @@ var Analytics = /** @class */ (function() {
         return null;
       }
     };
+    this.onError =
+      options.onError ||
+      function() {
+        throw new Error(JSON.stringify(errors, null, 2));
+      };
   }
   Analytics.prototype.addTypewriterContext = function(context) {
     if (context === void 0) {
@@ -97,7 +108,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "42_--terrible==event++name~!3",
@@ -173,7 +185,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Empty Event",
@@ -1025,7 +1038,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Example Event",
@@ -1101,7 +1115,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Draft-04 Event",
@@ -1177,7 +1192,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Draft-06 Event",

--- a/tests/commands/gen-js/__snapshots__/index.es5.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.js
@@ -37,8 +37,8 @@ var Analytics = /** @class */ (function() {
     };
     this.onError =
       options.onError ||
-      function() {
-        throw new Error(JSON.stringify(errors, null, 2));
+      function(error) {
+        throw new Error(JSON.stringify(error, null, 2));
       };
   }
   Analytics.prototype.addTypewriterContext = function(context) {
@@ -108,7 +108,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "42_--terrible==event++name~!3",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -185,7 +188,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Empty Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -1038,7 +1044,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Example Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -1115,7 +1124,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-04 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -1192,7 +1204,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-06 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(

--- a/tests/commands/gen-js/__snapshots__/index.es5.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.node.js
@@ -18,9 +18,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var Analytics = /** @class */ (function() {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics-node library to wrap
+   * @param {Analytics} analytics The analytics-node library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  function Analytics(analytics) {
+  function Analytics(analytics, options) {
+    if (options === void 0) {
+      options = {};
+    }
     if (!analytics) {
       throw new Error("An instance of analytics-node must be provided");
     }
@@ -29,6 +35,11 @@ var Analytics = /** @class */ (function() {
         return null;
       }
     };
+    this.onError =
+      options.onError ||
+      function() {
+        throw new Error(JSON.stringify(errors, null, 2));
+      };
   }
   Analytics.prototype.addTypewriterContext = function(context) {
     if (context === void 0) {
@@ -94,7 +105,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = __assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -164,7 +176,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = __assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -1010,7 +1023,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = __assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -1080,7 +1094,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = __assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -1150,7 +1165,8 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = __assign({}, message, {
       context: this.addTypewriterContext(message.context),

--- a/tests/commands/gen-js/__snapshots__/index.es5.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.es5.node.js
@@ -37,8 +37,8 @@ var Analytics = /** @class */ (function() {
     };
     this.onError =
       options.onError ||
-      function() {
-        throw new Error(JSON.stringify(errors, null, 2));
+      function(error) {
+        throw new Error(JSON.stringify(error, null, 2));
       };
   }
   Analytics.prototype.addTypewriterContext = function(context) {
@@ -105,7 +105,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "42_--terrible==event++name~!3",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = __assign({}, message, {
@@ -176,7 +179,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Empty Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = __assign({}, message, {
@@ -1023,7 +1029,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Example Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = __assign({}, message, {
@@ -1094,7 +1103,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-04 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = __assign({}, message, {
@@ -1165,7 +1177,10 @@ var Analytics = /** @class */ (function() {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-06 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = __assign({}, message, {

--- a/tests/commands/gen-js/__snapshots__/index.js
+++ b/tests/commands/gen-js/__snapshots__/index.js
@@ -13,8 +13,8 @@ export default class Analytics {
     this.analytics = analytics || { track: () => null };
     this.onError =
       options.onError ||
-      (() => {
-        throw new Error(JSON.stringify(errors, null, 2));
+      (error => {
+        throw new Error(JSON.stringify(error, null, 2));
       });
   }
   addTypewriterContext(context = {}) {
@@ -76,7 +76,10 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "42_--terrible==event++name~!3",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -148,7 +151,10 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Empty Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -996,7 +1002,10 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Example Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -1068,7 +1077,10 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-04 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(
@@ -1140,7 +1152,10 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-06 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     this.analytics.track(

--- a/tests/commands/gen-js/__snapshots__/index.js
+++ b/tests/commands/gen-js/__snapshots__/index.js
@@ -1,13 +1,21 @@
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics.js library to wrap
+   * @param {Analytics} analytics The analytics.js library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     if (!analytics) {
       throw new Error("An instance of analytics.js must be provided");
     }
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (() => {
+        throw new Error(JSON.stringify(errors, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return {
@@ -68,7 +76,8 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "42_--terrible==event++name~!3",
@@ -139,7 +148,8 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Empty Event",
@@ -986,7 +996,8 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Example Event",
@@ -1057,7 +1068,8 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Draft-04 Event",
@@ -1128,7 +1140,8 @@ export default class Analytics {
       return errors === 0;
     };
     if (!validate({ properties: props })) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     this.analytics.track(
       "Draft-06 Event",

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -280,23 +280,30 @@ export interface RequiredObject {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
-interface AnalyticsOptions {
-  onError: (
-    error: {
-      eventName: string;
-      validationErrors: Array<{
-        keyword: string;
-        dataPath: string;
-        schemaPath: string;
-        params: object;
-        message: string;
-        propertyName?: string;
-        parentSchema?: object;
-        data?: any;
-      }>;
-    }
-  ) => void;
+
+// From https://github.com/epoberezkin/ajv/blob/0c31c1e2a81e315511c60a0dd7420a72cb181e61/lib/ajv.d.ts#L279
+interface AjvErrorObject {
+  keyword: string;
+  dataPath: string;
+  schemaPath: string;
+  params: object;
+  message: string;
+  propertyName?: string;
+  parentSchema?: object;
+  data?: any;
 }
+
+// An invalid event with its associated collection of validation errors.
+interface InvalidEvent {
+  eventName: string;
+  validationErrors: AjvErrorObject[];
+}
+
+// Options to customize the runtime behavior of a Typewriter client.
+interface AnalyticsOptions {
+  onError(event: InvalidEvent): void;
+}
+
 export default class Analytics {
   constructor(analytics: any, options?: AnalyticsOptions);
 

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -280,8 +280,25 @@ export interface RequiredObject {
  * Analytics provides a strongly-typed wrapper around Segment Analytics
  * based on your Tracking Plan.
  */
+interface AnalyticsOptions {
+  onError: (
+    error: {
+      eventName: string;
+      validationErrors: Array<{
+        keyword: string;
+        dataPath: string;
+        schemaPath: string;
+        params: object;
+        message: string;
+        propertyName?: string;
+        parentSchema?: object;
+        data?: any;
+      }>;
+    }
+  ) => void;
+}
 export default class Analytics {
-  constructor(analytics: any, options: { onError: (errors: object) => void });
+  constructor(analytics: any, options?: AnalyticsOptions);
 
   the42TerribleEventName3(
     message?: TrackMessage<The42_TerribleEventName3>,

--- a/tests/commands/gen-js/__snapshots__/index.node.d.ts
+++ b/tests/commands/gen-js/__snapshots__/index.node.d.ts
@@ -281,7 +281,7 @@ export interface RequiredObject {
  * based on your Tracking Plan.
  */
 export default class Analytics {
-  constructor(analytics: any);
+  constructor(analytics: any, options: { onError: (errors: object) => void });
 
   the42TerribleEventName3(
     message?: TrackMessage<The42_TerribleEventName3>,

--- a/tests/commands/gen-js/__snapshots__/index.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.node.js
@@ -15,8 +15,8 @@ class Analytics {
     this.analytics = analytics || { track: () => null };
     this.onError =
       options.onError ||
-      (() => {
-        throw new Error(JSON.stringify(errors, null, 2));
+      (error => {
+        throw new Error(JSON.stringify(error, null, 2));
       });
   }
   addTypewriterContext(context = {}) {
@@ -77,7 +77,10 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "42_--terrible==event++name~!3",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = Object.assign({}, message, {
@@ -145,7 +148,10 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Empty Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = Object.assign({}, message, {
@@ -989,7 +995,10 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Example Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = Object.assign({}, message, {
@@ -1057,7 +1066,10 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-04 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = Object.assign({}, message, {
@@ -1125,7 +1137,10 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      this.onError(validate.errors);
+      this.onError({
+        eventName: "Draft-06 Event",
+        validationErrors: validate.errors
+      });
       return;
     }
     message = Object.assign({}, message, {

--- a/tests/commands/gen-js/__snapshots__/index.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.node.js
@@ -3,13 +3,21 @@ Object.defineProperty(exports, "__esModule", { value: true });
 class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics-node library to wrap
+   * @param {Analytics} analytics The analytics-node library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     if (!analytics) {
       throw new Error("An instance of analytics-node must be provided");
     }
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (() => {
+        throw new Error(JSON.stringify(errors, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return Object.assign({}, context, {
@@ -69,7 +77,8 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = Object.assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -136,7 +145,8 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = Object.assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -979,7 +989,8 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = Object.assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -1046,7 +1057,8 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = Object.assign({}, message, {
       context: this.addTypewriterContext(message.context),
@@ -1113,7 +1125,8 @@ class Analytics {
       return errors === 0;
     };
     if (!validate(message)) {
-      throw new Error(JSON.stringify(validate.errors, null, 2));
+      this.onError(validate.errors);
+      return;
     }
     message = Object.assign({}, message, {
       context: this.addTypewriterContext(message.context),

--- a/tests/commands/gen-js/__snapshots__/index.prod.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.js
@@ -8,11 +8,6 @@ export default class Analytics {
    */
   constructor(analytics, options = {}) {
     this.analytics = analytics || { track: () => null };
-    this.onError =
-      options.onError ||
-      (() => {
-        throw new Error(JSON.stringify(errors, null, 2));
-      });
   }
   addTypewriterContext(context = {}) {
     return {

--- a/tests/commands/gen-js/__snapshots__/index.prod.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.js
@@ -1,10 +1,18 @@
 export default class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics.js library to wrap
+   * @param {Analytics} analytics The analytics.js library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (() => {
+        throw new Error(JSON.stringify(errors, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return {

--- a/tests/commands/gen-js/__snapshots__/index.prod.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.node.js
@@ -10,11 +10,6 @@ class Analytics {
    */
   constructor(analytics, options = {}) {
     this.analytics = analytics || { track: () => null };
-    this.onError =
-      options.onError ||
-      (() => {
-        throw new Error(JSON.stringify(errors, null, 2));
-      });
   }
   addTypewriterContext(context = {}) {
     return Object.assign({}, context, {

--- a/tests/commands/gen-js/__snapshots__/index.prod.node.js
+++ b/tests/commands/gen-js/__snapshots__/index.prod.node.js
@@ -3,10 +3,18 @@ Object.defineProperty(exports, "__esModule", { value: true });
 class Analytics {
   /**
    * Instantiate a wrapper around an analytics library instance
-   * @param {Analytics} analytics - The analytics-node library to wrap
+   * @param {Analytics} analytics The analytics-node library to wrap
+   * @param {Object} [options] Optional configuration of the Typewriter client
+   * @param {function} [options.onError] Error handler fired when run-time validation errors
+   *     are raised.
    */
-  constructor(analytics) {
+  constructor(analytics, options = {}) {
     this.analytics = analytics || { track: () => null };
+    this.onError =
+      options.onError ||
+      (() => {
+        throw new Error(JSON.stringify(errors, null, 2));
+      });
   }
   addTypewriterContext(context = {}) {
     return Object.assign({}, context, {

--- a/tests/commands/gen-js/__snapshots__/index.system.js
+++ b/tests/commands/gen-js/__snapshots__/index.system.js
@@ -8,13 +8,21 @@ System.register([], function(exports_1, context_1) {
       Analytics = class Analytics {
         /**
          * Instantiate a wrapper around an analytics library instance
-         * @param {Analytics} analytics - The analytics.js library to wrap
+         * @param {Analytics} analytics The analytics.js library to wrap
+         * @param {Object} [options] Optional configuration of the Typewriter client
+         * @param {function} [options.onError] Error handler fired when run-time validation errors
+         *     are raised.
          */
-        constructor(analytics) {
+        constructor(analytics, options = {}) {
           if (!analytics) {
             throw new Error("An instance of analytics.js must be provided");
           }
           this.analytics = analytics || { track: () => null };
+          this.onError =
+            options.onError ||
+            (() => {
+              throw new Error(JSON.stringify(errors, null, 2));
+            });
         }
         addTypewriterContext(context = {}) {
           return {
@@ -79,7 +87,8 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            throw new Error(JSON.stringify(validate.errors, null, 2));
+            this.onError(validate.errors);
+            return;
           }
           this.analytics.track(
             "42_--terrible==event++name~!3",
@@ -154,7 +163,8 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            throw new Error(JSON.stringify(validate.errors, null, 2));
+            this.onError(validate.errors);
+            return;
           }
           this.analytics.track(
             "Empty Event",
@@ -1069,7 +1079,8 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            throw new Error(JSON.stringify(validate.errors, null, 2));
+            this.onError(validate.errors);
+            return;
           }
           this.analytics.track(
             "Example Event",
@@ -1144,7 +1155,8 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            throw new Error(JSON.stringify(validate.errors, null, 2));
+            this.onError(validate.errors);
+            return;
           }
           this.analytics.track(
             "Draft-04 Event",
@@ -1219,7 +1231,8 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            throw new Error(JSON.stringify(validate.errors, null, 2));
+            this.onError(validate.errors);
+            return;
           }
           this.analytics.track(
             "Draft-06 Event",

--- a/tests/commands/gen-js/__snapshots__/index.system.js
+++ b/tests/commands/gen-js/__snapshots__/index.system.js
@@ -20,8 +20,8 @@ System.register([], function(exports_1, context_1) {
           this.analytics = analytics || { track: () => null };
           this.onError =
             options.onError ||
-            (() => {
-              throw new Error(JSON.stringify(errors, null, 2));
+            (error => {
+              throw new Error(JSON.stringify(error, null, 2));
             });
         }
         addTypewriterContext(context = {}) {
@@ -87,7 +87,10 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            this.onError(validate.errors);
+            this.onError({
+              eventName: "42_--terrible==event++name~!3",
+              validationErrors: validate.errors
+            });
             return;
           }
           this.analytics.track(
@@ -163,7 +166,10 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            this.onError(validate.errors);
+            this.onError({
+              eventName: "Empty Event",
+              validationErrors: validate.errors
+            });
             return;
           }
           this.analytics.track(
@@ -1079,7 +1085,10 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            this.onError(validate.errors);
+            this.onError({
+              eventName: "Example Event",
+              validationErrors: validate.errors
+            });
             return;
           }
           this.analytics.track(
@@ -1155,7 +1164,10 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            this.onError(validate.errors);
+            this.onError({
+              eventName: "Draft-04 Event",
+              validationErrors: validate.errors
+            });
             return;
           }
           this.analytics.track(
@@ -1231,7 +1243,10 @@ System.register([], function(exports_1, context_1) {
             return errors === 0;
           };
           if (!validate({ properties: props })) {
-            this.onError(validate.errors);
+            this.onError({
+              eventName: "Draft-06 Event",
+              validationErrors: validate.errors
+            });
             return;
           }
           this.analytics.track(

--- a/tests/commands/gen-js/__snapshots__/index.umd.js
+++ b/tests/commands/gen-js/__snapshots__/index.umd.js
@@ -23,8 +23,8 @@
       this.analytics = analytics || { track: () => null };
       this.onError =
         options.onError ||
-        (() => {
-          throw new Error(JSON.stringify(errors, null, 2));
+        (error => {
+          throw new Error(JSON.stringify(error, null, 2));
         });
     }
     addTypewriterContext(context = {}) {
@@ -86,7 +86,10 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "42_--terrible==event++name~!3",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -158,7 +161,10 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Empty Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -1045,7 +1051,10 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Example Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -1117,7 +1126,10 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Draft-04 Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(
@@ -1189,7 +1201,10 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        this.onError(validate.errors);
+        this.onError({
+          eventName: "Draft-06 Event",
+          validationErrors: validate.errors
+        });
         return;
       }
       this.analytics.track(

--- a/tests/commands/gen-js/__snapshots__/index.umd.js
+++ b/tests/commands/gen-js/__snapshots__/index.umd.js
@@ -11,13 +11,21 @@
   class Analytics {
     /**
      * Instantiate a wrapper around an analytics library instance
-     * @param {Analytics} analytics - The analytics.js library to wrap
+     * @param {Analytics} analytics The analytics.js library to wrap
+     * @param {Object} [options] Optional configuration of the Typewriter client
+     * @param {function} [options.onError] Error handler fired when run-time validation errors
+     *     are raised.
      */
-    constructor(analytics) {
+    constructor(analytics, options = {}) {
       if (!analytics) {
         throw new Error("An instance of analytics.js must be provided");
       }
       this.analytics = analytics || { track: () => null };
+      this.onError =
+        options.onError ||
+        (() => {
+          throw new Error(JSON.stringify(errors, null, 2));
+        });
     }
     addTypewriterContext(context = {}) {
       return {
@@ -78,7 +86,8 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "42_--terrible==event++name~!3",
@@ -149,7 +158,8 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Empty Event",
@@ -1035,7 +1045,8 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Example Event",
@@ -1106,7 +1117,8 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Draft-04 Event",
@@ -1177,7 +1189,8 @@
         return errors === 0;
       };
       if (!validate({ properties: props })) {
-        throw new Error(JSON.stringify(validate.errors, null, 2));
+        this.onError(validate.errors);
+        return;
       }
       this.analytics.track(
         "Draft-06 Event",


### PR DESCRIPTION
From integrating Typewriter at Segment, we've learned that throwing an error whenever Typewriter discovers a validation issues is a pretty poor DX because it forces you to align your instrumentation and spec from day 1. Instead, we want to offer developers the opportunity to iteratively adopt Typewriter.

To do so, this PR exposes an `onError` handler that can be configured at run-time when constructing an instance of a Typewriter client.

As an example, this is what happens now when you have a validation error:

![image](https://user-images.githubusercontent.com/2907397/52014309-0f2edd00-2494-11e9-872a-d9e0b86e521f.png)

Your entire app breaks while developing locally -- and that interrupts your developer flow.

Now, you can hook in to that error handling logic like so:

```js
const analytics = new Analytics(window.analytics, {
   onError: (error) => {
       console.error(JSON.stringify(error, null, 2))
   }
})
```

After doing this, the errors will get logged instead:

![image](https://user-images.githubusercontent.com/2907397/52014714-228e7800-2495-11e9-9e68-84d3cdf7cee6.png)

This allows you to handle errors however you want! For example, you could `alert` on errors:

![image](https://user-images.githubusercontent.com/2907397/52014438-5f0da400-2494-11e9-8744-263d82ef5f48.png)

Or you could use this to ship validation to production without crashing your app and forward validation issues to Sentry/BugSnag/etc.