### PR TITLE
Run `snyk wizard` and bump handlebars

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,51 +1,51 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.12.0
+version: v1.13.5
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-LODASH-450202:
     - snyk > snyk-nuget-plugin > lodash:
         reason: None given
         expires: '2019-09-16T22:23:31.599Z'
-      snyk > @snyk/dep-graph > lodash:
-        reason: None given
-        expires: '2019-10-22T04:37:26.400Z'
     - snyk > snyk-nodejs-lockfile-parser > lodash:
         reason: None given
         expires: '2019-09-16T22:23:31.599Z'
-      snyk > inquirer > lodash:
-        reason: None given
-        expires: '2019-10-22T04:37:26.401Z'
     - snyk > snyk-config > lodash:
         reason: None given
         expires: '2019-10-22T04:37:26.401Z'
     - snyk > inquirer > lodash:
         reason: None given
         expires: '2019-09-16T22:23:31.600Z'
-      snyk > snyk-nodejs-lockfile-parser > lodash:
-        reason: None given
-        expires: '2019-10-22T04:37:26.401Z'
     - snyk > @snyk/dep-graph > lodash:
         reason: None given
         expires: '2019-09-16T22:23:31.600Z'
-      snyk > snyk-nuget-plugin > lodash:
-        reason: None given
-        expires: '2019-10-22T04:37:26.401Z'
     - snyk > snyk-go-plugin > graphlib > lodash:
         reason: None given
         expires: '2019-09-16T22:23:31.600Z'
-      snyk > @snyk/dep-graph > graphlib > lodash:
-        reason: None given
-        expires: '2019-10-22T04:37:26.401Z'
     - snyk > snyk-nodejs-lockfile-parser > graphlib > lodash:
         reason: None given
         expires: '2019-09-16T22:23:31.600Z'
-      snyk > snyk-go-plugin > graphlib > lodash:
+    - snyk > @snyk/dep-graph > graphlib > lodash:
+        reason: None given
+        expires: '2019-09-16T22:23:31.600Z'
+    - snyk > @snyk/dep-graph > lodash:
+        reason: None given
+        expires: '2019-10-22T04:37:26.400Z'
+    - snyk > inquirer > lodash:
+        reason: None given
+        expires: '2019-10-22T04:37:26.401Z'
+    - snyk > snyk-nodejs-lockfile-parser > lodash:
+        reason: None given
+        expires: '2019-10-22T04:37:26.401Z'
+    - snyk > snyk-nuget-plugin > lodash:
         reason: None given
         expires: '2019-10-22T04:37:26.401Z'
     - snyk > @snyk/dep-graph > graphlib > lodash:
         reason: None given
-        expires: '2019-09-16T22:23:31.600Z'
-      snyk > snyk-nodejs-lockfile-parser > graphlib > lodash:
+        expires: '2019-10-22T04:37:26.401Z'
+    - snyk > snyk-go-plugin > graphlib > lodash:
+        reason: None given
+        expires: '2019-10-22T04:37:26.401Z'
+    - snyk > snyk-nodejs-lockfile-parser > graphlib > lodash:
         reason: None given
         expires: '2019-10-22T04:37:26.401Z'
   SNYK-JS-AXIOS-174505:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
 XC_OBJECTIVE_C_ARGS := -workspace TypewriterExample.xcworkspace -scheme TypewriterExample -destination $(DESTINATION)
 XC_SWIFT_ARGS := -workspace TypewriterSwiftExample.xcworkspace -scheme TypewriterSwiftExample -destination $(DESTINATION)
 
-.PHONY: update prod bulk
+.PHONY: update build prod bulk
+build: COMMAND=build
+build: bulk
 prod: COMMAND=prod
 prod: bulk
 update: COMMAND=update

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run update && git add -A && lint-staged"
+      "pre-commit": "make build && git add -A && lint-staged"
     }
   },
   "snyk": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,10 +1374,15 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.14.1, commander@^2.9.0, commander@~2.20.0:
+commander@^2.14.1, commander@^2.9.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+
+commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 compare-versions@^3.2.1:
   version "3.4.0"
@@ -2586,9 +2591,9 @@ handlebars@^4.1.0, handlebars@^4.1.2:
     uglify-js "^3.1.4"
 
 handlebars@^4.3.0:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.4.3.tgz#180bae52c1d0e9ec0c15d7e82a4362d662762f6e"
-  integrity sha512-B0W4A2U1ww3q7VVthTKfh+epHx+q4mCt6iK+zEAzbMBpWQAwxCeKxEGpj/1oQTpzPXDNSOG7hmG14TsISH50yw==
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.2.tgz#5a4eb92ab5962ca3415ac188c86dc7f784f76a0f"
+  integrity sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4566,9 +4571,9 @@ needle@^2.2.4:
     sax "^1.2.4"
 
 neo-async@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.0.tgz#b9d15e4d71c6762908654b5183ed38b753340835"
-  integrity sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
+  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
 netmask@^1.0.6:
   version "1.0.6"
@@ -6945,11 +6950,11 @@ typewriter@^7.0.0-33:
     yargs "^13.2.2"
 
 uglify-js@^3.1.4:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.5.5.tgz#9c5aaaf3a7586fbf559df31fa6d3bca1b3ba7e9b"
-  integrity sha512-e58FqZzPwaLODQetDQKlvErZaGkh1UmzP8YwU0aG65NLourKNtwVyDG8tkIyUU0vqWzxaikSvTaxrCSscmvqvQ==
+  version "3.6.9"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.9.tgz#85d353edb6ddfb62a9d798f36e91792249320611"
+  integrity sha512-pcnnhaoG6RtrvHJ1dFncAe8Od6Nuy30oaJ82ts6//sGSXOP5UjBMEthiProjXmMNHOfd93sqlkztifFMcb+4yw==
   dependencies:
-    commander "~2.20.0"
+    commander "~2.20.3"
     source-map "~0.6.1"
 
 union-value@^1.0.0:


### PR DESCRIPTION
This PR updates the `handlebars` dependency.

It also updates the `pre-commit` hook to run typewriter's `build` instead of `update`, both a) so that you don't need to be a Segmenter to commit and b) so that changes to the Tracking Plan are opt-in rather than added on every commit.