### PR TITLE
Improve testing error when segmentio/mock is not running

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@ DESTINATION ?= "platform=iOS Simulator,name=iPhone 11"
 XC_OBJECTIVE_C_ARGS := -workspace TypewriterExample.xcworkspace -scheme TypewriterExample -destination $(DESTINATION)
 XC_SWIFT_ARGS := -workspace TypewriterSwiftExample.xcworkspace -scheme TypewriterSwiftExample -destination $(DESTINATION)
 
-.PHONY: update prod bulk
+.PHONY: update build prod bulk
+build: COMMAND=build
+build: bulk
 prod: COMMAND=prod
 prod: bulk
 update: COMMAND=update
@@ -67,7 +69,7 @@ docker:
 # clear-mock: Clears segmentio/mock to give an e2e test a clean slate.
 .PHONY: clear-mock
 clear-mock:
-	@curl -f "http://localhost:8765/messages" > /dev/null 2>&1
+	@curl -f "http://localhost:8765/messages" > /dev/null 2>&1 || (echo "Failed to clear segmentio/mock. Is it running? Try 'make docker'"; exit 1)
 
 # teardown: shuts down the sidecar.
 .PHONY: teardown

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test": "jest --testPathIgnorePatterns 'tests/e2e/.*' 'example'",
     "e2e": "make e2e",
     "update": "make update",
-    "prod": "make prod",
     "lint": "eslint './src/**/*.{ts,tsx}'",
     "release": "yarn run build && np",
     "prerelease": "yarn run build && np prerelease --any-branch --tag next --no-release-draft"
@@ -175,7 +174,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run update && git add -A && lint-staged"
+      "pre-commit": "make build && git add -A && lint-staged"
     }
   },
   "snyk": true


### PR DESCRIPTION
This PR changes the error message that is generated when running typewriter's test suite locally without `segmentio/mock` running.