### PR TITLE
Add e2e test for large integers and floats

### DIFF
--- a/src/generators/ios/ios.ts
+++ b/src/generators/ios/ios.ts
@@ -72,7 +72,7 @@ export const ios: Generator<{}, IOSTrackCallContext, IOSObjectContext, IOSProper
 			p.type = p.isVariableNullable ? 'BOOL *' : 'BOOL'
 			p.isPointerType = p.isVariableNullable
 		} else if (schema.type === Type.INTEGER) {
-			p.type = p.isVariableNullable ? 'NSInteger *' : 'NSInteger'
+			p.type = p.isVariableNullable ? 'NSNumber *' : 'NSInteger'
 			p.isPointerType = p.isVariableNullable
 		} else if (schema.type === Type.NUMBER) {
 			p.type = 'NSNumber *'
@@ -264,7 +264,7 @@ function generatePropertiesDictionary(
 					: `[NSNumber numberWithBool:${name}]`
 				: property.schemaType === Type.INTEGER
 				? property.isPointerType
-					? `[NSNumber numberWithInteger:*${name}]`
+					? name
 					: `[NSNumber numberWithInteger:${name}]`
 				: property.schemaType === Type.OBJECT && !property.type.includes('SERIALIZABLE_DICT')
 				? `[${name} toDictionary]`

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterAnalytics.h
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterAnalytics.h
@@ -57,7 +57,7 @@ options:(nullable SERIALIZABLE_DICT)options;
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -66,7 +66,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex;
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -76,7 +76,7 @@ options:(nullable SERIALIZABLE_DICT)options;
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -85,7 +85,7 @@ requiredStringWithRegex:(nullable NSString *)requiredStringWithRegex;
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -95,7 +95,7 @@ options:(nullable SERIALIZABLE_DICT)options;
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -104,7 +104,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex;
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -128,6 +128,25 @@ requiredNumber:(nonnull NSNumber *)requiredNumber
 requiredObject:(nonnull SERIALIZABLE_DICT)requiredObject
 requiredString:(nonnull NSString *)requiredString
 requiredStringWithRegex:(nonnull NSString *)requiredStringWithRegex
+options:(nullable SERIALIZABLE_DICT)options;
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber;
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
 options:(nullable SERIALIZABLE_DICT)options;
 
 + (void)nestedArraysWithUniverseCharacters:(nonnull NSArray<NSArray<SEGUniverseCharactersItemItem *> *> *)universeCharacters;

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterAnalytics.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterAnalytics.m
@@ -126,7 +126,7 @@ options:(nullable SERIALIZABLE_DICT)options
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -138,7 +138,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -149,7 +149,7 @@ options:(nullable SERIALIZABLE_DICT)options
     properties[@"optional any"] = optionalAny == nil ? [NSNull null] : optionalAny;
     properties[@"optional array"] = optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:optionalArray];
     properties[@"optional boolean"] = optionalBoolean == nil ? [NSNull null] : [NSNumber numberWithBool:*optionalBoolean];
-    properties[@"optional int"] = optionalInt == nil ? [NSNull null] : [NSNumber numberWithInteger:*optionalInt];
+    properties[@"optional int"] = optionalInt == nil ? [NSNull null] : optionalInt;
     properties[@"optional number"] = optionalNumber == nil ? [NSNull null] : optionalNumber;
     properties[@"optional object"] = optionalObject == nil ? [NSNull null] : optionalObject;
     properties[@"optional string"] = optionalString == nil ? [NSNull null] : optionalString;
@@ -161,7 +161,7 @@ options:(nullable SERIALIZABLE_DICT)options
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -173,7 +173,7 @@ requiredStringWithRegex:(nullable NSString *)requiredStringWithRegex
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -184,7 +184,7 @@ options:(nullable SERIALIZABLE_DICT)options
     properties[@"required any"] = requiredAny == nil ? [NSNull null] : requiredAny;
     properties[@"required array"] = requiredArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:requiredArray];
     properties[@"required boolean"] = requiredBoolean == nil ? [NSNull null] : [NSNumber numberWithBool:*requiredBoolean];
-    properties[@"required int"] = requiredInt == nil ? [NSNull null] : [NSNumber numberWithInteger:*requiredInt];
+    properties[@"required int"] = requiredInt == nil ? [NSNull null] : requiredInt;
     properties[@"required number"] = requiredNumber == nil ? [NSNull null] : requiredNumber;
     properties[@"required object"] = requiredObject == nil ? [NSNull null] : requiredObject;
     properties[@"required string"] = requiredString == nil ? [NSNull null] : requiredString;
@@ -196,7 +196,7 @@ options:(nullable SERIALIZABLE_DICT)options
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -208,7 +208,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -224,7 +224,7 @@ options:(nullable SERIALIZABLE_DICT)options
       properties[@"optional boolean"] = [NSNumber numberWithBool:*optionalBoolean];
     }
     if (optionalInt != nil) {
-      properties[@"optional int"] = [NSNumber numberWithInteger:*optionalInt];
+      properties[@"optional int"] = optionalInt;
     }
     if (optionalNumber != nil) {
       properties[@"optional number"] = optionalNumber;
@@ -285,6 +285,47 @@ options:(nullable SERIALIZABLE_DICT)options
     }
 
     [[SEGAnalytics sharedAnalytics] track:@"Every Required Type" properties:properties options:[SEGTypewriterUtils withTypewriterContextFields:options]];
+}
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
+{
+    [SEGTypewriterAnalytics largeNumbersEventWithLargeNullableOptionalInteger:largeNullableOptionalInteger largeNullableOptionalNumber:largeNullableOptionalNumber largeNullableRequiredInteger:largeNullableRequiredInteger largeNullableRequiredNumber:largeNullableRequiredNumber largeOptionalInteger:largeOptionalInteger largeOptionalNumber:largeOptionalNumber largeRequiredInteger:largeRequiredInteger largeRequiredNumber:largeRequiredNumber options:@{}];
+}
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
+options:(nullable SERIALIZABLE_DICT)options
+{
+    NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
+    properties[@"large nullable optional integer"] = largeNullableOptionalInteger == nil ? [NSNull null] : largeNullableOptionalInteger;
+    properties[@"large nullable optional number"] = largeNullableOptionalNumber == nil ? [NSNull null] : largeNullableOptionalNumber;
+    properties[@"large nullable required integer"] = largeNullableRequiredInteger == nil ? [NSNull null] : largeNullableRequiredInteger;
+    properties[@"large nullable required number"] = largeNullableRequiredNumber == nil ? [NSNull null] : largeNullableRequiredNumber;
+    if (largeOptionalInteger != nil) {
+      properties[@"large optional integer"] = largeOptionalInteger;
+    }
+    if (largeOptionalNumber != nil) {
+      properties[@"large optional number"] = largeOptionalNumber;
+    }
+    properties[@"large required integer"] = [NSNumber numberWithInteger:largeRequiredInteger];
+    if (largeRequiredNumber != nil) {
+      properties[@"large required number"] = largeRequiredNumber;
+    }
+
+    [[SEGAnalytics sharedAnalytics] track:@"Large Numbers Event" properties:properties options:[SEGTypewriterUtils withTypewriterContextFields:options]];
 }
 
 + (void)nestedArraysWithUniverseCharacters:(nonnull NSArray<NSArray<SEGUniverseCharactersItemItem *> *> *)universeCharacters

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/plan.json
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/plan.json
@@ -62,6 +62,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.",
         "name": "Custom Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -89,6 +90,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.",
         "name": "Custom Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -107,6 +109,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.",
         "name": "Default Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -134,6 +137,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.",
         "name": "Default Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -152,6 +156,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.",
         "name": "Empty Event",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -170,6 +175,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "Event Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -188,6 +194,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.",
         "name": "Every Nullable Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -239,6 +246,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.",
         "name": "Every Nullable Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -301,6 +309,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as optional fields.",
         "name": "Every Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -353,6 +362,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as required fields. ",
         "name": "Every Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +426,67 @@
         "version": 1
       },
       {
+        "description": "Validates that clients correctly serialize large numbers (integers and floats).",
+        "name": "Large Numbers Event",
+        "rules": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "labels": {},
+          "properties": {
+            "context": {},
+            "properties": {
+              "properties": {
+                "large nullable optional integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable optional number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large nullable required integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable required number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large optional integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large optional number": {
+                  "description": "",
+                  "type": "number"
+                },
+                "large required integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large required number": {
+                  "description": "",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "large required integer",
+                "large required number",
+                "large nullable required integer",
+                "large nullable required number"
+              ],
+              "type": "object"
+            },
+            "traits": {
+              "type": "object"
+            }
+          },
+          "required": ["properties"],
+          "type": "object"
+        },
+        "version": 1
+      },
+      {
+        "description": "Validates that clients handle arrays-within-arrays.",
         "name": "Nested Arrays",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -457,6 +528,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle objects-within-objects.",
         "name": "Nested Objects",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -512,6 +584,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in property names within a single event.",
         "name": "Properties Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -542,6 +615,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #1",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -588,6 +662,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #2",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -634,6 +709,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients sanitize property names that contain invalid identifier characters.",
         "name": "Property Sanitized",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -660,6 +736,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with various types of arrays.",
         "name": "Simple Array Types",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -742,6 +819,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with multiple (union) types.",
         "name": "Union Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -768,6 +846,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "event_collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,5 +868,5 @@
     "group_traits": [],
     "identify_traits": []
   },
-  "update_time": "2019-10-16T23:36:31.000Z"
+  "update_time": "2019-11-15T17:43:14.000Z"
 }

--- a/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
+++ b/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
@@ -69,6 +69,8 @@
                                                                      ]
                                                                  ]];
     
+    [SEGTypewriterAnalytics largeNumbersEventWithLargeNullableOptionalInteger:@1230007112658965944 largeNullableOptionalNumber:@1240007112658965944331.0 largeNullableRequiredInteger:@1250007112658965944 largeNullableRequiredNumber:@1260007112658965944331.0 largeOptionalInteger:@1270007112658965944 largeOptionalNumber:@1280007112658965944331.0 largeRequiredInteger:1290007112658965944 largeRequiredNumber:@1300007112658965944331.0];
+
     // Note: flushing is an async operation in analytics-ios. Therefore, we use notifications to
     // identify when all events have finished flushing.
     __block BOOL finishedFlushing = false;

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGTypewriterAnalytics.h
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGTypewriterAnalytics.h
@@ -57,7 +57,7 @@ options:(nullable SERIALIZABLE_DICT)options;
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -66,7 +66,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex;
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -76,7 +76,7 @@ options:(nullable SERIALIZABLE_DICT)options;
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -85,7 +85,7 @@ requiredStringWithRegex:(nullable NSString *)requiredStringWithRegex;
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -95,7 +95,7 @@ options:(nullable SERIALIZABLE_DICT)options;
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -104,7 +104,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex;
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -128,6 +128,25 @@ requiredNumber:(nonnull NSNumber *)requiredNumber
 requiredObject:(nonnull SERIALIZABLE_DICT)requiredObject
 requiredString:(nonnull NSString *)requiredString
 requiredStringWithRegex:(nonnull NSString *)requiredStringWithRegex
+options:(nullable SERIALIZABLE_DICT)options;
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber;
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
 options:(nullable SERIALIZABLE_DICT)options;
 
 + (void)nestedArraysWithUniverseCharacters:(nonnull NSArray<NSArray<SEGUniverseCharactersItemItem *> *> *)universeCharacters;

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGTypewriterAnalytics.m
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGTypewriterAnalytics.m
@@ -126,7 +126,7 @@ options:(nullable SERIALIZABLE_DICT)options
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -138,7 +138,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 + (void)everyNullableOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -149,7 +149,7 @@ options:(nullable SERIALIZABLE_DICT)options
     properties[@"optional any"] = optionalAny == nil ? [NSNull null] : optionalAny;
     properties[@"optional array"] = optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:optionalArray];
     properties[@"optional boolean"] = optionalBoolean == nil ? [NSNull null] : [NSNumber numberWithBool:*optionalBoolean];
-    properties[@"optional int"] = optionalInt == nil ? [NSNull null] : [NSNumber numberWithInteger:*optionalInt];
+    properties[@"optional int"] = optionalInt == nil ? [NSNull null] : optionalInt;
     properties[@"optional number"] = optionalNumber == nil ? [NSNull null] : optionalNumber;
     properties[@"optional object"] = optionalObject == nil ? [NSNull null] : optionalObject;
     properties[@"optional string"] = optionalString == nil ? [NSNull null] : optionalString;
@@ -161,7 +161,7 @@ options:(nullable SERIALIZABLE_DICT)options
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -173,7 +173,7 @@ requiredStringWithRegex:(nullable NSString *)requiredStringWithRegex
 + (void)everyNullableRequiredTypeWithRequiredAny:(nullable id)requiredAny
 requiredArray:(nullable NSArray<id> *)requiredArray
 requiredBoolean:(nullable BOOL *)requiredBoolean
-requiredInt:(nullable NSInteger *)requiredInt
+requiredInt:(nullable NSNumber *)requiredInt
 requiredNumber:(nullable NSNumber *)requiredNumber
 requiredObject:(nullable SERIALIZABLE_DICT)requiredObject
 requiredString:(nullable NSString *)requiredString
@@ -184,7 +184,7 @@ options:(nullable SERIALIZABLE_DICT)options
     properties[@"required any"] = requiredAny == nil ? [NSNull null] : requiredAny;
     properties[@"required array"] = requiredArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:requiredArray];
     properties[@"required boolean"] = requiredBoolean == nil ? [NSNull null] : [NSNumber numberWithBool:*requiredBoolean];
-    properties[@"required int"] = requiredInt == nil ? [NSNull null] : [NSNumber numberWithInteger:*requiredInt];
+    properties[@"required int"] = requiredInt == nil ? [NSNull null] : requiredInt;
     properties[@"required number"] = requiredNumber == nil ? [NSNull null] : requiredNumber;
     properties[@"required object"] = requiredObject == nil ? [NSNull null] : requiredObject;
     properties[@"required string"] = requiredString == nil ? [NSNull null] : requiredString;
@@ -196,7 +196,7 @@ options:(nullable SERIALIZABLE_DICT)options
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -208,7 +208,7 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 + (void)everyOptionalTypeWithOptionalAny:(nullable id)optionalAny
 optionalArray:(nullable NSArray<id> *)optionalArray
 optionalBoolean:(nullable BOOL *)optionalBoolean
-optionalInt:(nullable NSInteger *)optionalInt
+optionalInt:(nullable NSNumber *)optionalInt
 optionalNumber:(nullable NSNumber *)optionalNumber
 optionalObject:(nullable SERIALIZABLE_DICT)optionalObject
 optionalString:(nullable NSString *)optionalString
@@ -224,7 +224,7 @@ options:(nullable SERIALIZABLE_DICT)options
       properties[@"optional boolean"] = [NSNumber numberWithBool:*optionalBoolean];
     }
     if (optionalInt != nil) {
-      properties[@"optional int"] = [NSNumber numberWithInteger:*optionalInt];
+      properties[@"optional int"] = optionalInt;
     }
     if (optionalNumber != nil) {
       properties[@"optional number"] = optionalNumber;
@@ -285,6 +285,47 @@ options:(nullable SERIALIZABLE_DICT)options
     }
 
     [[SEGAnalytics sharedAnalytics] track:@"Every Required Type" properties:properties options:[SEGTypewriterUtils withTypewriterContextFields:options]];
+}
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
+{
+    [SEGTypewriterAnalytics largeNumbersEventWithLargeNullableOptionalInteger:largeNullableOptionalInteger largeNullableOptionalNumber:largeNullableOptionalNumber largeNullableRequiredInteger:largeNullableRequiredInteger largeNullableRequiredNumber:largeNullableRequiredNumber largeOptionalInteger:largeOptionalInteger largeOptionalNumber:largeOptionalNumber largeRequiredInteger:largeRequiredInteger largeRequiredNumber:largeRequiredNumber options:@{}];
+}
+
++ (void)largeNumbersEventWithLargeNullableOptionalInteger:(nullable NSNumber *)largeNullableOptionalInteger
+largeNullableOptionalNumber:(nullable NSNumber *)largeNullableOptionalNumber
+largeNullableRequiredInteger:(nullable NSNumber *)largeNullableRequiredInteger
+largeNullableRequiredNumber:(nullable NSNumber *)largeNullableRequiredNumber
+largeOptionalInteger:(nullable NSNumber *)largeOptionalInteger
+largeOptionalNumber:(nullable NSNumber *)largeOptionalNumber
+largeRequiredInteger:(NSInteger)largeRequiredInteger
+largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
+options:(nullable SERIALIZABLE_DICT)options
+{
+    NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
+    properties[@"large nullable optional integer"] = largeNullableOptionalInteger == nil ? [NSNull null] : largeNullableOptionalInteger;
+    properties[@"large nullable optional number"] = largeNullableOptionalNumber == nil ? [NSNull null] : largeNullableOptionalNumber;
+    properties[@"large nullable required integer"] = largeNullableRequiredInteger == nil ? [NSNull null] : largeNullableRequiredInteger;
+    properties[@"large nullable required number"] = largeNullableRequiredNumber == nil ? [NSNull null] : largeNullableRequiredNumber;
+    if (largeOptionalInteger != nil) {
+      properties[@"large optional integer"] = largeOptionalInteger;
+    }
+    if (largeOptionalNumber != nil) {
+      properties[@"large optional number"] = largeOptionalNumber;
+    }
+    properties[@"large required integer"] = [NSNumber numberWithInteger:largeRequiredInteger];
+    if (largeRequiredNumber != nil) {
+      properties[@"large required number"] = largeRequiredNumber;
+    }
+
+    [[SEGAnalytics sharedAnalytics] track:@"Large Numbers Event" properties:properties options:[SEGTypewriterUtils withTypewriterContextFields:options]];
 }
 
 + (void)nestedArraysWithUniverseCharacters:(nonnull NSArray<NSArray<SEGUniverseCharactersItemItem *> *> *)universeCharacters

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/plan.json
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/plan.json
@@ -62,6 +62,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.",
         "name": "Custom Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -89,6 +90,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.",
         "name": "Custom Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -107,6 +109,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.",
         "name": "Default Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -134,6 +137,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.",
         "name": "Default Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -152,6 +156,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.",
         "name": "Empty Event",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -170,6 +175,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "Event Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -188,6 +194,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.",
         "name": "Every Nullable Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -239,6 +246,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.",
         "name": "Every Nullable Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -301,6 +309,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as optional fields.",
         "name": "Every Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -353,6 +362,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as required fields. ",
         "name": "Every Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +426,67 @@
         "version": 1
       },
       {
+        "description": "Validates that clients correctly serialize large numbers (integers and floats).",
+        "name": "Large Numbers Event",
+        "rules": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "labels": {},
+          "properties": {
+            "context": {},
+            "properties": {
+              "properties": {
+                "large nullable optional integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable optional number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large nullable required integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable required number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large optional integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large optional number": {
+                  "description": "",
+                  "type": "number"
+                },
+                "large required integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large required number": {
+                  "description": "",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "large required integer",
+                "large required number",
+                "large nullable required integer",
+                "large nullable required number"
+              ],
+              "type": "object"
+            },
+            "traits": {
+              "type": "object"
+            }
+          },
+          "required": ["properties"],
+          "type": "object"
+        },
+        "version": 1
+      },
+      {
+        "description": "Validates that clients handle arrays-within-arrays.",
         "name": "Nested Arrays",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -457,6 +528,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle objects-within-objects.",
         "name": "Nested Objects",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -512,6 +584,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in property names within a single event.",
         "name": "Properties Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -542,6 +615,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #1",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -588,6 +662,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #2",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -634,6 +709,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients sanitize property names that contain invalid identifier characters.",
         "name": "Property Sanitized",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -660,6 +736,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with various types of arrays.",
         "name": "Simple Array Types",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -742,6 +819,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with multiple (union) types.",
         "name": "Union Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -768,6 +846,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "event_collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,5 +868,5 @@
     "group_traits": [],
     "identify_traits": []
   },
-  "update_time": "2019-10-16T23:36:31.000Z"
+  "update_time": "2019-11-15T17:43:14.000Z"
 }

--- a/tests/e2e/ios-swift/TypewriterSwiftExampleTests/TypewriterSwiftExampleTests.swift
+++ b/tests/e2e/ios-swift/TypewriterSwiftExampleTests/TypewriterSwiftExampleTests.swift
@@ -54,6 +54,8 @@ class TypewriterSwiftExampleTests: XCTestCase {
             ]
         ])
 
+        SEGTypewriterAnalytics.largeNumbersEvent(withLargeNullableOptionalInteger: 1230007112658965944, largeNullableOptionalNumber: 1240007112658965944331.0, largeNullableRequiredInteger: 1250007112658965944, largeNullableRequiredNumber: 1260007112658965944331.0, largeOptionalInteger: 1270007112658965944, largeOptionalNumber: 1280007112658965944331.0, largeRequiredInteger: 1290007112658965944, largeRequiredNumber: 1300007112658965944331.0)
+
         // Note: flushing is an async operation in analytics-ios. Therefore, we use notifications to
         // identify when all events have finished flushing.
         var finishedFlushing = false

--- a/tests/e2e/node-javascript/analytics/index.js
+++ b/tests/e2e/node-javascript/analytics/index.js
@@ -183,6 +183,17 @@ function withTypewriterContext(message) {
  * @property {string} required string with regex - Required string property with a regex conditional
  */
 /**
+ * @typedef LargeNumbersEvent
+ * @property {number | null} [large nullable optional integer] -
+ * @property {number | null} [large nullable optional number] -
+ * @property {number | null} large nullable required integer -
+ * @property {number | null} large nullable required number -
+ * @property {number} [large optional integer] -
+ * @property {number} [large optional number] -
+ * @property {number} large required integer -
+ * @property {number} large required number -
+ */
+/**
  * @typedef UniverseCharactersItemItem
  * @property {string} name - The character's name.
  */
@@ -378,7 +389,7 @@ function analyticsInstanceMissingThrewError(message, callback) {
 }
 exports.analyticsInstanceMissingThrewError = analyticsInstanceMissingThrewError
 /**
- * Fires a 'Custom Violation Handler' track call.
+ * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
  *
  * @param {TrackMessage<CustomViolationHandler>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -390,6 +401,8 @@ function customViolationHandler(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -422,7 +435,7 @@ function customViolationHandler(message, callback) {
 }
 exports.customViolationHandler = customViolationHandler
 /**
- * Fires a 'Custom Violation Handler Called' track call.
+ * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -436,6 +449,8 @@ function customViolationHandlerCalled(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -459,7 +474,7 @@ function customViolationHandlerCalled(message, callback) {
 }
 exports.customViolationHandlerCalled = customViolationHandlerCalled
 /**
- * Fires a 'Default Violation Handler' track call.
+ * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
  *
  * @param {TrackMessage<DefaultViolationHandler>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -473,6 +488,8 @@ function defaultViolationHandler(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -505,7 +522,7 @@ function defaultViolationHandler(message, callback) {
 }
 exports.defaultViolationHandler = defaultViolationHandler
 /**
- * Fires a 'Default Violation Handler Called' track call.
+ * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -519,6 +536,8 @@ function defaultViolationHandlerCalled(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -542,7 +561,7 @@ function defaultViolationHandlerCalled(message, callback) {
 }
 exports.defaultViolationHandlerCalled = defaultViolationHandlerCalled
 /**
- * Fires a 'Empty Event' track call.
+ * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -554,6 +573,8 @@ function emptyEvent(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.',
 		labels: {},
 		properties: {
 			context: {},
@@ -577,7 +598,7 @@ function emptyEvent(message, callback) {
 }
 exports.emptyEvent = emptyEvent
 /**
- * Fires a 'Event Collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -589,6 +610,8 @@ function eventCollided(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -612,7 +635,7 @@ function eventCollided(message, callback) {
 }
 exports.eventCollided = eventCollided
 /**
- * Fires a 'Every Nullable Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
  *
  * @param {TrackMessage<EveryNullableOptionalType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -626,6 +649,8 @@ function everyNullableOptionalType(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -682,7 +707,7 @@ function everyNullableOptionalType(message, callback) {
 }
 exports.everyNullableOptionalType = everyNullableOptionalType
 /**
- * Fires a 'Every Nullable Required Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
  *
  * @param {TrackMessage<EveryNullableRequiredType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -696,6 +721,8 @@ function everyNullableRequiredType(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -763,7 +790,7 @@ function everyNullableRequiredType(message, callback) {
 }
 exports.everyNullableRequiredType = everyNullableRequiredType
 /**
- * Fires a 'Every Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as optional fields.
  *
  * @param {TrackMessage<EveryOptionalType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -775,6 +802,8 @@ function everyOptionalType(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as optional fields.',
 		properties: {
 			context: {},
 			properties: {
@@ -832,7 +861,7 @@ function everyOptionalType(message, callback) {
 }
 exports.everyOptionalType = everyOptionalType
 /**
- * Fires a 'Every Required Type' track call.
+ * Validates that clients handle all of the supported field types, as required fields.
  *
  * @param {TrackMessage<EveryRequiredType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -844,6 +873,8 @@ function everyRequiredType(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as required fields. ',
 		properties: {
 			context: {},
 			properties: {
@@ -912,7 +943,85 @@ function everyRequiredType(message, callback) {
 }
 exports.everyRequiredType = everyRequiredType
 /**
- * Fires a 'Nested Arrays' track call.
+ * Validates that clients correctly serialize large numbers (integers and floats).
+ *
+ * @param {TrackMessage<LargeNumbersEvent>} message - The analytics properties that will be sent to Segment.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 		call is fired.
+ */
+function largeNumbersEvent(message, callback) {
+	var msg = withTypewriterContext(
+		__assign({ properties: {} }, message, { event: 'Large Numbers Event' })
+	)
+	var schema = {
+		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients correctly serialize large numbers (integers and floats).',
+		labels: {},
+		properties: {
+			context: {},
+			properties: {
+				properties: {
+					'large nullable optional integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable optional number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large nullable required integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable required number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large optional integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large optional number': {
+						description: '',
+						type: 'number',
+					},
+					'large required integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large required number': {
+						description: '',
+						type: 'number',
+					},
+				},
+				required: [
+					'large required integer',
+					'large required number',
+					'large nullable required integer',
+					'large nullable required number',
+				],
+				type: 'object',
+			},
+			traits: {
+				type: 'object',
+			},
+		},
+		required: ['properties'],
+		title: 'Large Numbers Event',
+		type: 'object',
+	}
+	validateAgainstSchema(msg, schema)
+	var a = analytics()
+	if (a) {
+		a.track(msg, callback)
+	} else {
+		throw missingAnalyticsNodeError
+	}
+}
+exports.largeNumbersEvent = largeNumbersEvent
+/**
+ * Validates that clients handle arrays-within-arrays.
  *
  * @param {TrackMessage<NestedArrays>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -924,6 +1033,7 @@ function nestedArrays(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle arrays-within-arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -970,7 +1080,7 @@ function nestedArrays(message, callback) {
 }
 exports.nestedArrays = nestedArrays
 /**
- * Fires a 'Nested Objects' track call.
+ * Validates that clients handle objects-within-objects.
  *
  * @param {TrackMessage<NestedObjects>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -982,6 +1092,7 @@ function nestedObjects(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle objects-within-objects.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1042,7 +1153,7 @@ function nestedObjects(message, callback) {
 }
 exports.nestedObjects = nestedObjects
 /**
- * Fires a 'Properties Collided' track call.
+ * Validates that clients handle collisions in property names within a single event.
  *
  * @param {TrackMessage<PropertiesCollided>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1054,6 +1165,8 @@ function propertiesCollided(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in property names within a single event.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1089,7 +1202,7 @@ function propertiesCollided(message, callback) {
 }
 exports.propertiesCollided = propertiesCollided
 /**
- * Fires a 'Property Object Name Collision #1' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {TrackMessage<PropertyObjectNameCollision1>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1103,6 +1216,8 @@ function propertyObjectNameCollision1(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1154,7 +1269,7 @@ function propertyObjectNameCollision1(message, callback) {
 }
 exports.propertyObjectNameCollision1 = propertyObjectNameCollision1
 /**
- * Fires a 'Property Object Name Collision #2' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {TrackMessage<PropertyObjectNameCollision2>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1168,6 +1283,8 @@ function propertyObjectNameCollision2(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1219,7 +1336,7 @@ function propertyObjectNameCollision2(message, callback) {
 }
 exports.propertyObjectNameCollision2 = propertyObjectNameCollision2
 /**
- * Fires a 'Property Sanitized' track call.
+ * Validates that clients sanitize property names that contain invalid identifier characters.
  *
  * @param {TrackMessage<PropertySanitized>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1231,6 +1348,8 @@ function propertySanitized(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients sanitize property names that contain invalid identifier characters.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1262,7 +1381,7 @@ function propertySanitized(message, callback) {
 }
 exports.propertySanitized = propertySanitized
 /**
- * Fires a 'Simple Array Types' track call.
+ * Validates that clients support fields with various types of arrays.
  *
  * @param {TrackMessage<SimpleArrayTypes>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1274,6 +1393,8 @@ function simpleArrayTypes(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with various types of arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1361,7 +1482,7 @@ function simpleArrayTypes(message, callback) {
 }
 exports.simpleArrayTypes = simpleArrayTypes
 /**
- * Fires a 'Union Type' track call.
+ * Validates that clients support fields with multiple (union) types.
  *
  * @param {TrackMessage<UnionType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1373,6 +1494,8 @@ function unionType(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with multiple (union) types.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1404,7 +1527,7 @@ function unionType(message, callback) {
 }
 exports.unionType = unionType
 /**
- * Fires a 'event_collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1416,6 +1539,8 @@ function eventCollided1(message, callback) {
 	)
 	var schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1480,7 +1605,7 @@ var clientAPI = {
 	 */
 	analyticsInstanceMissingThrewError: analyticsInstanceMissingThrewError,
 	/**
-	 * Fires a 'Custom Violation Handler' track call.
+	 * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {TrackMessage<CustomViolationHandler>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1488,7 +1613,7 @@ var clientAPI = {
 	 */
 	customViolationHandler: customViolationHandler,
 	/**
-	 * Fires a 'Custom Violation Handler Called' track call.
+	 * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1496,7 +1621,7 @@ var clientAPI = {
 	 */
 	customViolationHandlerCalled: customViolationHandlerCalled,
 	/**
-	 * Fires a 'Default Violation Handler' track call.
+	 * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {TrackMessage<DefaultViolationHandler>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1504,7 +1629,7 @@ var clientAPI = {
 	 */
 	defaultViolationHandler: defaultViolationHandler,
 	/**
-	 * Fires a 'Default Violation Handler Called' track call.
+	 * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1512,7 +1637,7 @@ var clientAPI = {
 	 */
 	defaultViolationHandlerCalled: defaultViolationHandlerCalled,
 	/**
-	 * Fires a 'Empty Event' track call.
+	 * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1520,7 +1645,7 @@ var clientAPI = {
 	 */
 	emptyEvent: emptyEvent,
 	/**
-	 * Fires a 'Event Collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1528,7 +1653,7 @@ var clientAPI = {
 	 */
 	eventCollided: eventCollided,
 	/**
-	 * Fires a 'Every Nullable Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
 	 *
 	 * @param {TrackMessage<EveryNullableOptionalType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1536,7 +1661,7 @@ var clientAPI = {
 	 */
 	everyNullableOptionalType: everyNullableOptionalType,
 	/**
-	 * Fires a 'Every Nullable Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
 	 *
 	 * @param {TrackMessage<EveryNullableRequiredType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1544,7 +1669,7 @@ var clientAPI = {
 	 */
 	everyNullableRequiredType: everyNullableRequiredType,
 	/**
-	 * Fires a 'Every Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as optional fields.
 	 *
 	 * @param {TrackMessage<EveryOptionalType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1552,7 +1677,7 @@ var clientAPI = {
 	 */
 	everyOptionalType: everyOptionalType,
 	/**
-	 * Fires a 'Every Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as required fields.
 	 *
 	 * @param {TrackMessage<EveryRequiredType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1560,7 +1685,15 @@ var clientAPI = {
 	 */
 	everyRequiredType: everyRequiredType,
 	/**
-	 * Fires a 'Nested Arrays' track call.
+	 * Validates that clients correctly serialize large numbers (integers and floats).
+	 *
+	 * @param {TrackMessage<LargeNumbersEvent>} message - The analytics properties that will be sent to Segment.
+	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+	 * 		call is fired.
+	 */
+	largeNumbersEvent: largeNumbersEvent,
+	/**
+	 * Validates that clients handle arrays-within-arrays.
 	 *
 	 * @param {TrackMessage<NestedArrays>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1568,7 +1701,7 @@ var clientAPI = {
 	 */
 	nestedArrays: nestedArrays,
 	/**
-	 * Fires a 'Nested Objects' track call.
+	 * Validates that clients handle objects-within-objects.
 	 *
 	 * @param {TrackMessage<NestedObjects>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1576,7 +1709,7 @@ var clientAPI = {
 	 */
 	nestedObjects: nestedObjects,
 	/**
-	 * Fires a 'Properties Collided' track call.
+	 * Validates that clients handle collisions in property names within a single event.
 	 *
 	 * @param {TrackMessage<PropertiesCollided>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1584,7 +1717,7 @@ var clientAPI = {
 	 */
 	propertiesCollided: propertiesCollided,
 	/**
-	 * Fires a 'Property Object Name Collision #1' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {TrackMessage<PropertyObjectNameCollision1>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1592,7 +1725,7 @@ var clientAPI = {
 	 */
 	propertyObjectNameCollision1: propertyObjectNameCollision1,
 	/**
-	 * Fires a 'Property Object Name Collision #2' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {TrackMessage<PropertyObjectNameCollision2>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1600,7 +1733,7 @@ var clientAPI = {
 	 */
 	propertyObjectNameCollision2: propertyObjectNameCollision2,
 	/**
-	 * Fires a 'Property Sanitized' track call.
+	 * Validates that clients sanitize property names that contain invalid identifier characters.
 	 *
 	 * @param {TrackMessage<PropertySanitized>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1608,7 +1741,7 @@ var clientAPI = {
 	 */
 	propertySanitized: propertySanitized,
 	/**
-	 * Fires a 'Simple Array Types' track call.
+	 * Validates that clients support fields with various types of arrays.
 	 *
 	 * @param {TrackMessage<SimpleArrayTypes>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1616,7 +1749,7 @@ var clientAPI = {
 	 */
 	simpleArrayTypes: simpleArrayTypes,
 	/**
-	 * Fires a 'Union Type' track call.
+	 * Validates that clients support fields with multiple (union) types.
 	 *
 	 * @param {TrackMessage<UnionType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1624,7 +1757,7 @@ var clientAPI = {
 	 */
 	unionType: unionType,
 	/**
-	 * Fires a 'event_collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics

--- a/tests/e2e/node-javascript/analytics/plan.json
+++ b/tests/e2e/node-javascript/analytics/plan.json
@@ -62,6 +62,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.",
         "name": "Custom Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -89,6 +90,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.",
         "name": "Custom Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -107,6 +109,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.",
         "name": "Default Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -134,6 +137,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.",
         "name": "Default Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -152,6 +156,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.",
         "name": "Empty Event",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -170,6 +175,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "Event Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -188,6 +194,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.",
         "name": "Every Nullable Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -239,6 +246,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.",
         "name": "Every Nullable Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -301,6 +309,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as optional fields.",
         "name": "Every Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -353,6 +362,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as required fields. ",
         "name": "Every Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +426,67 @@
         "version": 1
       },
       {
+        "description": "Validates that clients correctly serialize large numbers (integers and floats).",
+        "name": "Large Numbers Event",
+        "rules": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "labels": {},
+          "properties": {
+            "context": {},
+            "properties": {
+              "properties": {
+                "large nullable optional integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable optional number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large nullable required integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable required number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large optional integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large optional number": {
+                  "description": "",
+                  "type": "number"
+                },
+                "large required integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large required number": {
+                  "description": "",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "large required integer",
+                "large required number",
+                "large nullable required integer",
+                "large nullable required number"
+              ],
+              "type": "object"
+            },
+            "traits": {
+              "type": "object"
+            }
+          },
+          "required": ["properties"],
+          "type": "object"
+        },
+        "version": 1
+      },
+      {
+        "description": "Validates that clients handle arrays-within-arrays.",
         "name": "Nested Arrays",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -457,6 +528,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle objects-within-objects.",
         "name": "Nested Objects",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -512,6 +584,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in property names within a single event.",
         "name": "Properties Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -542,6 +615,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #1",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -588,6 +662,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #2",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -634,6 +709,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients sanitize property names that contain invalid identifier characters.",
         "name": "Property Sanitized",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -660,6 +736,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with various types of arrays.",
         "name": "Simple Array Types",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -742,6 +819,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with multiple (union) types.",
         "name": "Union Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -768,6 +846,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "event_collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,5 +868,5 @@
     "group_traits": [],
     "identify_traits": []
   },
-  "update_time": "2019-10-16T23:36:31.000Z"
+  "update_time": "2019-11-15T17:43:14.000Z"
 }

--- a/tests/e2e/node-javascript/index.js
+++ b/tests/e2e/node-javascript/index.js
@@ -24,6 +24,7 @@ const {
 	customViolationHandlerCalled,
 	analyticsInstanceMissingThrewError,
 	propertySanitized,
+	largeNumbersEvent,
 } = require('./analytics')
 const typewriter = require('./analytics').default
 const SegmentAnalytics = require('analytics-node')
@@ -290,6 +291,20 @@ async function run() {
 	// There is no generated function for `aMissingAnalyticsCall`, but the JS Proxy should
 	// handle this and avoid a crash.
 	typewriter.aMissingAnalyticsCall({
+		userId,
+	})
+
+	largeNumbersEvent({
+		properties: {
+			'large nullable optional integer': 1230007112658965944,
+			'large nullable optional number': 1240007112658965944331.0,
+			'large nullable required integer': 1250007112658965944,
+			'large nullable required number': 1260007112658965944331.0,
+			'large optional integer': 1270007112658965944,
+			'large optional number': 1280007112658965944331.0,
+			'large required integer': 1290007112658965944,
+			'large required number': 1300007112658965944331.0,
+		},
 		userId,
 	})
 

--- a/tests/e2e/node-typescript/analytics/index.ts
+++ b/tests/e2e/node-typescript/analytics/index.ts
@@ -155,6 +155,16 @@ export interface EveryRequiredType {
 	 */
 	'required string with regex': string
 }
+export interface LargeNumbersEvent {
+	'large nullable optional integer'?: number | null
+	'large nullable optional number'?: number | null
+	'large nullable required integer': number | null
+	'large nullable required number': number | null
+	'large optional integer'?: number
+	'large optional number'?: number
+	'large required integer': number
+	'large required number': number
+}
 export interface UniverseCharactersItemItem {
 	/**
 	 * The character's name.
@@ -434,6 +444,17 @@ function withTypewriterContext<P, T extends Segment.TrackMessage<P>>(
  * @property {string} required string with regex - Required string property with a regex conditional
  */
 /**
+ * @typedef LargeNumbersEvent
+ * @property {number | null} [large nullable optional integer] -
+ * @property {number | null} [large nullable optional number] -
+ * @property {number | null} large nullable required integer -
+ * @property {number | null} large nullable required number -
+ * @property {number} [large optional integer] -
+ * @property {number} [large optional number] -
+ * @property {number} large required integer -
+ * @property {number} large required number -
+ */
+/**
  * @typedef UniverseCharactersItemItem
  * @property {string} name - The character's name.
  */
@@ -642,7 +663,7 @@ export function analyticsInstanceMissingThrewError(
 	}
 }
 /**
- * Fires a 'Custom Violation Handler' track call.
+ * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
  *
  * @param {TrackMessage<CustomViolationHandler>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -660,6 +681,8 @@ export function customViolationHandler(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -692,7 +715,7 @@ export function customViolationHandler(
 	}
 }
 /**
- * Fires a 'Custom Violation Handler Called' track call.
+ * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -710,6 +733,8 @@ export function customViolationHandlerCalled(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -733,7 +758,7 @@ export function customViolationHandlerCalled(
 	}
 }
 /**
- * Fires a 'Default Violation Handler' track call.
+ * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
  *
  * @param {TrackMessage<DefaultViolationHandler>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -751,6 +776,8 @@ export function defaultViolationHandler(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -783,7 +810,7 @@ export function defaultViolationHandler(
 	}
 }
 /**
- * Fires a 'Default Violation Handler Called' track call.
+ * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -801,6 +828,8 @@ export function defaultViolationHandlerCalled(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -824,7 +853,7 @@ export function defaultViolationHandlerCalled(
 	}
 }
 /**
- * Fires a 'Empty Event' track call.
+ * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -842,6 +871,8 @@ export function emptyEvent(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.',
 		labels: {},
 		properties: {
 			context: {},
@@ -865,7 +896,7 @@ export function emptyEvent(
 	}
 }
 /**
- * Fires a 'Event Collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -883,6 +914,8 @@ export function eventCollided(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -906,7 +939,7 @@ export function eventCollided(
 	}
 }
 /**
- * Fires a 'Every Nullable Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
  *
  * @param {TrackMessage<EveryNullableOptionalType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -924,6 +957,8 @@ export function everyNullableOptionalType(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -980,7 +1015,7 @@ export function everyNullableOptionalType(
 	}
 }
 /**
- * Fires a 'Every Nullable Required Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
  *
  * @param {TrackMessage<EveryNullableRequiredType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -998,6 +1033,8 @@ export function everyNullableRequiredType(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -1065,7 +1102,7 @@ export function everyNullableRequiredType(
 	}
 }
 /**
- * Fires a 'Every Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as optional fields.
  *
  * @param {TrackMessage<EveryOptionalType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1083,6 +1120,8 @@ export function everyOptionalType(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as optional fields.',
 		properties: {
 			context: {},
 			properties: {
@@ -1140,7 +1179,7 @@ export function everyOptionalType(
 	}
 }
 /**
- * Fires a 'Every Required Type' track call.
+ * Validates that clients handle all of the supported field types, as required fields.
  *
  * @param {TrackMessage<EveryRequiredType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1158,6 +1197,8 @@ export function everyRequiredType(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as required fields. ',
 		properties: {
 			context: {},
 			properties: {
@@ -1226,7 +1267,91 @@ export function everyRequiredType(
 	}
 }
 /**
- * Fires a 'Nested Arrays' track call.
+ * Validates that clients correctly serialize large numbers (integers and floats).
+ *
+ * @param {TrackMessage<LargeNumbersEvent>} message - The analytics properties that will be sent to Segment.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 		call is fired.
+ */
+export function largeNumbersEvent(
+	message: Segment.TrackMessage<LargeNumbersEvent>,
+	callback?: Segment.Callback
+): void {
+	const msg = withTypewriterContext({
+		properties: {},
+		...message,
+		event: 'Large Numbers Event',
+	})
+
+	const schema = {
+		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients correctly serialize large numbers (integers and floats).',
+		labels: {},
+		properties: {
+			context: {},
+			properties: {
+				properties: {
+					'large nullable optional integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable optional number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large nullable required integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable required number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large optional integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large optional number': {
+						description: '',
+						type: 'number',
+					},
+					'large required integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large required number': {
+						description: '',
+						type: 'number',
+					},
+				},
+				required: [
+					'large required integer',
+					'large required number',
+					'large nullable required integer',
+					'large nullable required number',
+				],
+				type: 'object',
+			},
+			traits: {
+				type: 'object',
+			},
+		},
+		required: ['properties'],
+		title: 'Large Numbers Event',
+		type: 'object',
+	}
+	validateAgainstSchema(msg, schema)
+
+	const a = analytics()
+	if (a) {
+		a.track(msg, callback)
+	} else {
+		throw missingAnalyticsNodeError
+	}
+}
+/**
+ * Validates that clients handle arrays-within-arrays.
  *
  * @param {TrackMessage<NestedArrays>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1244,6 +1369,7 @@ export function nestedArrays(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle arrays-within-arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1290,7 +1416,7 @@ export function nestedArrays(
 	}
 }
 /**
- * Fires a 'Nested Objects' track call.
+ * Validates that clients handle objects-within-objects.
  *
  * @param {TrackMessage<NestedObjects>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1308,6 +1434,7 @@ export function nestedObjects(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle objects-within-objects.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1368,7 +1495,7 @@ export function nestedObjects(
 	}
 }
 /**
- * Fires a 'Properties Collided' track call.
+ * Validates that clients handle collisions in property names within a single event.
  *
  * @param {TrackMessage<PropertiesCollided>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1386,6 +1513,8 @@ export function propertiesCollided(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in property names within a single event.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1421,7 +1550,7 @@ export function propertiesCollided(
 	}
 }
 /**
- * Fires a 'Property Object Name Collision #1' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {TrackMessage<PropertyObjectNameCollision1>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1439,6 +1568,8 @@ export function propertyObjectNameCollision1(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1490,7 +1621,7 @@ export function propertyObjectNameCollision1(
 	}
 }
 /**
- * Fires a 'Property Object Name Collision #2' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {TrackMessage<PropertyObjectNameCollision2>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1508,6 +1639,8 @@ export function propertyObjectNameCollision2(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1559,7 +1692,7 @@ export function propertyObjectNameCollision2(
 	}
 }
 /**
- * Fires a 'Property Sanitized' track call.
+ * Validates that clients sanitize property names that contain invalid identifier characters.
  *
  * @param {TrackMessage<PropertySanitized>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1577,6 +1710,8 @@ export function propertySanitized(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients sanitize property names that contain invalid identifier characters.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1608,7 +1743,7 @@ export function propertySanitized(
 	}
 }
 /**
- * Fires a 'Simple Array Types' track call.
+ * Validates that clients support fields with various types of arrays.
  *
  * @param {TrackMessage<SimpleArrayTypes>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1626,6 +1761,8 @@ export function simpleArrayTypes(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with various types of arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1713,7 +1850,7 @@ export function simpleArrayTypes(
 	}
 }
 /**
- * Fires a 'Union Type' track call.
+ * Validates that clients support fields with multiple (union) types.
  *
  * @param {TrackMessage<UnionType>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1731,6 +1868,8 @@ export function unionType(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with multiple (union) types.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1762,7 +1901,7 @@ export function unionType(
 	}
 }
 /**
- * Fires a 'event_collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
  * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1780,6 +1919,8 @@ export function eventCollided1(
 
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1845,7 +1986,7 @@ const clientAPI = {
 	 */
 	analyticsInstanceMissingThrewError,
 	/**
-	 * Fires a 'Custom Violation Handler' track call.
+	 * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {TrackMessage<CustomViolationHandler>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1853,7 +1994,7 @@ const clientAPI = {
 	 */
 	customViolationHandler,
 	/**
-	 * Fires a 'Custom Violation Handler Called' track call.
+	 * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1861,7 +2002,7 @@ const clientAPI = {
 	 */
 	customViolationHandlerCalled,
 	/**
-	 * Fires a 'Default Violation Handler' track call.
+	 * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {TrackMessage<DefaultViolationHandler>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1869,7 +2010,7 @@ const clientAPI = {
 	 */
 	defaultViolationHandler,
 	/**
-	 * Fires a 'Default Violation Handler Called' track call.
+	 * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1877,7 +2018,7 @@ const clientAPI = {
 	 */
 	defaultViolationHandlerCalled,
 	/**
-	 * Fires a 'Empty Event' track call.
+	 * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1885,7 +2026,7 @@ const clientAPI = {
 	 */
 	emptyEvent,
 	/**
-	 * Fires a 'Event Collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1893,7 +2034,7 @@ const clientAPI = {
 	 */
 	eventCollided,
 	/**
-	 * Fires a 'Every Nullable Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
 	 *
 	 * @param {TrackMessage<EveryNullableOptionalType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1901,7 +2042,7 @@ const clientAPI = {
 	 */
 	everyNullableOptionalType,
 	/**
-	 * Fires a 'Every Nullable Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
 	 *
 	 * @param {TrackMessage<EveryNullableRequiredType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1909,7 +2050,7 @@ const clientAPI = {
 	 */
 	everyNullableRequiredType,
 	/**
-	 * Fires a 'Every Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as optional fields.
 	 *
 	 * @param {TrackMessage<EveryOptionalType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1917,7 +2058,7 @@ const clientAPI = {
 	 */
 	everyOptionalType,
 	/**
-	 * Fires a 'Every Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as required fields.
 	 *
 	 * @param {TrackMessage<EveryRequiredType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1925,7 +2066,15 @@ const clientAPI = {
 	 */
 	everyRequiredType,
 	/**
-	 * Fires a 'Nested Arrays' track call.
+	 * Validates that clients correctly serialize large numbers (integers and floats).
+	 *
+	 * @param {TrackMessage<LargeNumbersEvent>} message - The analytics properties that will be sent to Segment.
+	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+	 * 		call is fired.
+	 */
+	largeNumbersEvent,
+	/**
+	 * Validates that clients handle arrays-within-arrays.
 	 *
 	 * @param {TrackMessage<NestedArrays>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1933,7 +2082,7 @@ const clientAPI = {
 	 */
 	nestedArrays,
 	/**
-	 * Fires a 'Nested Objects' track call.
+	 * Validates that clients handle objects-within-objects.
 	 *
 	 * @param {TrackMessage<NestedObjects>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1941,7 +2090,7 @@ const clientAPI = {
 	 */
 	nestedObjects,
 	/**
-	 * Fires a 'Properties Collided' track call.
+	 * Validates that clients handle collisions in property names within a single event.
 	 *
 	 * @param {TrackMessage<PropertiesCollided>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1949,7 +2098,7 @@ const clientAPI = {
 	 */
 	propertiesCollided,
 	/**
-	 * Fires a 'Property Object Name Collision #1' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {TrackMessage<PropertyObjectNameCollision1>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1957,7 +2106,7 @@ const clientAPI = {
 	 */
 	propertyObjectNameCollision1,
 	/**
-	 * Fires a 'Property Object Name Collision #2' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {TrackMessage<PropertyObjectNameCollision2>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1965,7 +2114,7 @@ const clientAPI = {
 	 */
 	propertyObjectNameCollision2,
 	/**
-	 * Fires a 'Property Sanitized' track call.
+	 * Validates that clients sanitize property names that contain invalid identifier characters.
 	 *
 	 * @param {TrackMessage<PropertySanitized>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1973,7 +2122,7 @@ const clientAPI = {
 	 */
 	propertySanitized,
 	/**
-	 * Fires a 'Simple Array Types' track call.
+	 * Validates that clients support fields with various types of arrays.
 	 *
 	 * @param {TrackMessage<SimpleArrayTypes>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1981,7 +2130,7 @@ const clientAPI = {
 	 */
 	simpleArrayTypes,
 	/**
-	 * Fires a 'Union Type' track call.
+	 * Validates that clients support fields with multiple (union) types.
 	 *
 	 * @param {TrackMessage<UnionType>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
@@ -1989,7 +2138,7 @@ const clientAPI = {
 	 */
 	unionType,
 	/**
-	 * Fires a 'event_collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {TrackMessage<Record<string, any>>} message - The analytics properties that will be sent to Segment.
 	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics

--- a/tests/e2e/node-typescript/analytics/plan.json
+++ b/tests/e2e/node-typescript/analytics/plan.json
@@ -62,6 +62,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.",
         "name": "Custom Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -89,6 +90,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.",
         "name": "Custom Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -107,6 +109,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.",
         "name": "Default Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -134,6 +137,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.",
         "name": "Default Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -152,6 +156,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.",
         "name": "Empty Event",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -170,6 +175,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "Event Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -188,6 +194,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.",
         "name": "Every Nullable Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -239,6 +246,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.",
         "name": "Every Nullable Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -301,6 +309,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as optional fields.",
         "name": "Every Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -353,6 +362,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as required fields. ",
         "name": "Every Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +426,67 @@
         "version": 1
       },
       {
+        "description": "Validates that clients correctly serialize large numbers (integers and floats).",
+        "name": "Large Numbers Event",
+        "rules": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "labels": {},
+          "properties": {
+            "context": {},
+            "properties": {
+              "properties": {
+                "large nullable optional integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable optional number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large nullable required integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable required number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large optional integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large optional number": {
+                  "description": "",
+                  "type": "number"
+                },
+                "large required integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large required number": {
+                  "description": "",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "large required integer",
+                "large required number",
+                "large nullable required integer",
+                "large nullable required number"
+              ],
+              "type": "object"
+            },
+            "traits": {
+              "type": "object"
+            }
+          },
+          "required": ["properties"],
+          "type": "object"
+        },
+        "version": 1
+      },
+      {
+        "description": "Validates that clients handle arrays-within-arrays.",
         "name": "Nested Arrays",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -457,6 +528,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle objects-within-objects.",
         "name": "Nested Objects",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -512,6 +584,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in property names within a single event.",
         "name": "Properties Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -542,6 +615,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #1",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -588,6 +662,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #2",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -634,6 +709,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients sanitize property names that contain invalid identifier characters.",
         "name": "Property Sanitized",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -660,6 +736,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with various types of arrays.",
         "name": "Simple Array Types",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -742,6 +819,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with multiple (union) types.",
         "name": "Union Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -768,6 +846,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "event_collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,5 +868,5 @@
     "group_traits": [],
     "identify_traits": []
   },
-  "update_time": "2019-10-16T23:36:31.000Z"
+  "update_time": "2019-11-15T17:43:14.000Z"
 }

--- a/tests/e2e/node-typescript/index.ts
+++ b/tests/e2e/node-typescript/index.ts
@@ -23,6 +23,7 @@ import typewriter, {
 	customViolationHandlerCalled,
 	analyticsInstanceMissingThrewError,
 	propertySanitized,
+	largeNumbersEvent,
 } from './analytics'
 import SegmentAnalytics from 'analytics-node'
 import { promisify } from 'util'
@@ -292,6 +293,20 @@ async function run() {
 	// There is no generated function for `aMissingAnalyticsCall`, but the JS Proxy should
 	// handle this and avoid a crash.
 	typewriterWithoutTypes.aMissingAnalyticsCall({
+		userId,
+	})
+
+	largeNumbersEvent({
+		properties: {
+			'large nullable optional integer': 1230007112658965944,
+			'large nullable optional number': 1240007112658965944331.0,
+			'large nullable required integer': 1250007112658965944,
+			'large nullable required number': 1260007112658965944331.0,
+			'large optional integer': 1270007112658965944,
+			'large optional number': 1280007112658965944331.0,
+			'large required integer': 1290007112658965944,
+			'large required number': 1300007112658965944331.0,
+		},
 		userId,
 	})
 

--- a/tests/e2e/suite.test.ts
+++ b/tests/e2e/suite.test.ts
@@ -336,9 +336,24 @@ describe('e2e tests', () => {
 				},
 			},
 		},
+		{
+			name: 'large numbers are serialized correctly',
+			expect: {
+				name: 'Large Numbers Event',
+				properties: {
+					'large nullable optional integer': 1230007112658965944,
+					'large nullable optional number': 1240007112658965944331.0,
+					'large nullable required integer': 1250007112658965944,
+					'large nullable required number': 1260007112658965944331.0,
+					'large optional integer': 1270007112658965944,
+					'large optional number': 1280007112658965944331.0,
+					'large required integer': 1290007112658965944,
+					'large required number': 1300007112658965944331.0,
+				},
+			},
+		},
 		// TODO: can we add tests to validate the behavior of the default violation handler
 		// outside of test mode (NODE_ENV!=test)?
-		// TODO: add tests with large integers + large numbers
 		// TODO: add test of supplying custom context fields
 	]
 

--- a/tests/e2e/web-javascript/analytics/index.js
+++ b/tests/e2e/web-javascript/analytics/index.js
@@ -133,6 +133,17 @@ function withTypewriterContext(message = {}) {
  * @property {string} required string with regex - Required string property with a regex conditional
  */
 /**
+ * @typedef LargeNumbersEvent
+ * @property {number | null} [large nullable optional integer] -
+ * @property {number | null} [large nullable optional number] -
+ * @property {number | null} large nullable required integer -
+ * @property {number | null} large nullable required number -
+ * @property {number} [large optional integer] -
+ * @property {number} [large optional number] -
+ * @property {number} large required integer -
+ * @property {number} large required number -
+ */
+/**
  * @typedef UniverseCharactersItemItem
  * @property {string} name - The character's name.
  */
@@ -337,7 +348,7 @@ export function analyticsInstanceMissingThrewError(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Custom Violation Handler' track call.
+ * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
  *
  * @param {CustomViolationHandler} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -347,6 +358,8 @@ export function analyticsInstanceMissingThrewError(props, options, callback) {
 export function customViolationHandler(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -386,7 +399,7 @@ export function customViolationHandler(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Custom Violation Handler Called' track call.
+ * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -396,6 +409,8 @@ export function customViolationHandler(props, options, callback) {
 export function customViolationHandlerCalled(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -426,7 +441,7 @@ export function customViolationHandlerCalled(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Default Violation Handler' track call.
+ * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
  *
  * @param {DefaultViolationHandler} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -436,6 +451,8 @@ export function customViolationHandlerCalled(props, options, callback) {
 export function defaultViolationHandler(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -475,7 +492,7 @@ export function defaultViolationHandler(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Default Violation Handler Called' track call.
+ * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -485,6 +502,8 @@ export function defaultViolationHandler(props, options, callback) {
 export function defaultViolationHandlerCalled(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -515,7 +534,7 @@ export function defaultViolationHandlerCalled(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Empty Event' track call.
+ * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -525,6 +544,8 @@ export function defaultViolationHandlerCalled(props, options, callback) {
 export function emptyEvent(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.',
 		labels: {},
 		properties: {
 			context: {},
@@ -555,7 +576,7 @@ export function emptyEvent(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Event Collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -565,6 +586,8 @@ export function emptyEvent(props, options, callback) {
 export function eventCollided(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -595,7 +618,7 @@ export function eventCollided(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Every Nullable Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
  *
  * @param {EveryNullableOptionalType} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -605,6 +628,8 @@ export function eventCollided(props, options, callback) {
 export function everyNullableOptionalType(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -668,7 +693,7 @@ export function everyNullableOptionalType(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Every Nullable Required Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
  *
  * @param {EveryNullableRequiredType} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -678,6 +703,8 @@ export function everyNullableOptionalType(props, options, callback) {
 export function everyNullableRequiredType(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -752,7 +779,7 @@ export function everyNullableRequiredType(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Every Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as optional fields.
  *
  * @param {EveryOptionalType} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -762,6 +789,8 @@ export function everyNullableRequiredType(props, options, callback) {
 export function everyOptionalType(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as optional fields.',
 		properties: {
 			context: {},
 			properties: {
@@ -826,7 +855,7 @@ export function everyOptionalType(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Every Required Type' track call.
+ * Validates that clients handle all of the supported field types, as required fields.
  *
  * @param {EveryRequiredType} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -836,6 +865,8 @@ export function everyOptionalType(props, options, callback) {
 export function everyRequiredType(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as required fields. ',
 		properties: {
 			context: {},
 			properties: {
@@ -911,7 +942,90 @@ export function everyRequiredType(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Nested Arrays' track call.
+ * Validates that clients correctly serialize large numbers (integers and floats).
+ *
+ * @param {LargeNumbersEvent} props - The analytics properties that will be sent to Segment.
+ * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 		call is fired.
+ */
+export function largeNumbersEvent(props, options, callback) {
+	const schema = {
+		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients correctly serialize large numbers (integers and floats).',
+		labels: {},
+		properties: {
+			context: {},
+			properties: {
+				properties: {
+					'large nullable optional integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable optional number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large nullable required integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable required number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large optional integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large optional number': {
+						description: '',
+						type: 'number',
+					},
+					'large required integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large required number': {
+						description: '',
+						type: 'number',
+					},
+				},
+				required: [
+					'large required integer',
+					'large required number',
+					'large nullable required integer',
+					'large nullable required number',
+				],
+				type: 'object',
+			},
+			traits: {
+				type: 'object',
+			},
+		},
+		required: ['properties'],
+		title: 'Large Numbers Event',
+		type: 'object',
+	}
+	const message = {
+		event: 'Large Numbers Event',
+		properties: props || {},
+		options,
+	}
+	validateAgainstSchema(message, schema)
+	const a = analytics()
+	if (a) {
+		a.track(
+			'Large Numbers Event',
+			props || {},
+			withTypewriterContext(options),
+			callback
+		)
+	}
+}
+/**
+ * Validates that clients handle arrays-within-arrays.
  *
  * @param {NestedArrays} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -921,6 +1035,7 @@ export function everyRequiredType(props, options, callback) {
 export function nestedArrays(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle arrays-within-arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -974,7 +1089,7 @@ export function nestedArrays(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Nested Objects' track call.
+ * Validates that clients handle objects-within-objects.
  *
  * @param {NestedObjects} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -984,6 +1099,7 @@ export function nestedArrays(props, options, callback) {
 export function nestedObjects(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle objects-within-objects.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1051,7 +1167,7 @@ export function nestedObjects(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Properties Collided' track call.
+ * Validates that clients handle collisions in property names within a single event.
  *
  * @param {PropertiesCollided} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1061,6 +1177,8 @@ export function nestedObjects(props, options, callback) {
 export function propertiesCollided(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in property names within a single event.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1103,7 +1221,7 @@ export function propertiesCollided(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Property Object Name Collision #1' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {PropertyObjectNameCollision1} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1113,6 +1231,8 @@ export function propertiesCollided(props, options, callback) {
 export function propertyObjectNameCollision1(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1171,7 +1291,7 @@ export function propertyObjectNameCollision1(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Property Object Name Collision #2' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {PropertyObjectNameCollision2} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1181,6 +1301,8 @@ export function propertyObjectNameCollision1(props, options, callback) {
 export function propertyObjectNameCollision2(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1239,7 +1361,7 @@ export function propertyObjectNameCollision2(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Property Sanitized' track call.
+ * Validates that clients sanitize property names that contain invalid identifier characters.
  *
  * @param {PropertySanitized} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1249,6 +1371,8 @@ export function propertyObjectNameCollision2(props, options, callback) {
 export function propertySanitized(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients sanitize property names that contain invalid identifier characters.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1287,7 +1411,7 @@ export function propertySanitized(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Simple Array Types' track call.
+ * Validates that clients support fields with various types of arrays.
  *
  * @param {SimpleArrayTypes} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1297,6 +1421,8 @@ export function propertySanitized(props, options, callback) {
 export function simpleArrayTypes(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with various types of arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1391,7 +1517,7 @@ export function simpleArrayTypes(props, options, callback) {
 	}
 }
 /**
- * Fires a 'Union Type' track call.
+ * Validates that clients support fields with multiple (union) types.
  *
  * @param {UnionType} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1401,6 +1527,8 @@ export function simpleArrayTypes(props, options, callback) {
 export function unionType(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with multiple (union) types.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1434,7 +1562,7 @@ export function unionType(props, options, callback) {
 	}
 }
 /**
- * Fires a 'event_collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1444,6 +1572,8 @@ export function unionType(props, options, callback) {
 export function eventCollided1(props, options, callback) {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1516,7 +1646,7 @@ const clientAPI = {
 	 */
 	analyticsInstanceMissingThrewError,
 	/**
-	 * Fires a 'Custom Violation Handler' track call.
+	 * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {CustomViolationHandler} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1525,7 +1655,7 @@ const clientAPI = {
 	 */
 	customViolationHandler,
 	/**
-	 * Fires a 'Custom Violation Handler Called' track call.
+	 * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1534,7 +1664,7 @@ const clientAPI = {
 	 */
 	customViolationHandlerCalled,
 	/**
-	 * Fires a 'Default Violation Handler' track call.
+	 * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {DefaultViolationHandler} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1543,7 +1673,7 @@ const clientAPI = {
 	 */
 	defaultViolationHandler,
 	/**
-	 * Fires a 'Default Violation Handler Called' track call.
+	 * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1552,7 +1682,7 @@ const clientAPI = {
 	 */
 	defaultViolationHandlerCalled,
 	/**
-	 * Fires a 'Empty Event' track call.
+	 * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1561,7 +1691,7 @@ const clientAPI = {
 	 */
 	emptyEvent,
 	/**
-	 * Fires a 'Event Collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1570,7 +1700,7 @@ const clientAPI = {
 	 */
 	eventCollided,
 	/**
-	 * Fires a 'Every Nullable Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
 	 *
 	 * @param {EveryNullableOptionalType} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1579,7 +1709,7 @@ const clientAPI = {
 	 */
 	everyNullableOptionalType,
 	/**
-	 * Fires a 'Every Nullable Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
 	 *
 	 * @param {EveryNullableRequiredType} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1588,7 +1718,7 @@ const clientAPI = {
 	 */
 	everyNullableRequiredType,
 	/**
-	 * Fires a 'Every Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as optional fields.
 	 *
 	 * @param {EveryOptionalType} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1597,7 +1727,7 @@ const clientAPI = {
 	 */
 	everyOptionalType,
 	/**
-	 * Fires a 'Every Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as required fields.
 	 *
 	 * @param {EveryRequiredType} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1606,7 +1736,16 @@ const clientAPI = {
 	 */
 	everyRequiredType,
 	/**
-	 * Fires a 'Nested Arrays' track call.
+	 * Validates that clients correctly serialize large numbers (integers and floats).
+	 *
+	 * @param {LargeNumbersEvent} props - The analytics properties that will be sent to Segment.
+	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+	 * 		call is fired.
+	 */
+	largeNumbersEvent,
+	/**
+	 * Validates that clients handle arrays-within-arrays.
 	 *
 	 * @param {NestedArrays} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1615,7 +1754,7 @@ const clientAPI = {
 	 */
 	nestedArrays,
 	/**
-	 * Fires a 'Nested Objects' track call.
+	 * Validates that clients handle objects-within-objects.
 	 *
 	 * @param {NestedObjects} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1624,7 +1763,7 @@ const clientAPI = {
 	 */
 	nestedObjects,
 	/**
-	 * Fires a 'Properties Collided' track call.
+	 * Validates that clients handle collisions in property names within a single event.
 	 *
 	 * @param {PropertiesCollided} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1633,7 +1772,7 @@ const clientAPI = {
 	 */
 	propertiesCollided,
 	/**
-	 * Fires a 'Property Object Name Collision #1' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {PropertyObjectNameCollision1} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1642,7 +1781,7 @@ const clientAPI = {
 	 */
 	propertyObjectNameCollision1,
 	/**
-	 * Fires a 'Property Object Name Collision #2' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {PropertyObjectNameCollision2} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1651,7 +1790,7 @@ const clientAPI = {
 	 */
 	propertyObjectNameCollision2,
 	/**
-	 * Fires a 'Property Sanitized' track call.
+	 * Validates that clients sanitize property names that contain invalid identifier characters.
 	 *
 	 * @param {PropertySanitized} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1660,7 +1799,7 @@ const clientAPI = {
 	 */
 	propertySanitized,
 	/**
-	 * Fires a 'Simple Array Types' track call.
+	 * Validates that clients support fields with various types of arrays.
 	 *
 	 * @param {SimpleArrayTypes} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1669,7 +1808,7 @@ const clientAPI = {
 	 */
 	simpleArrayTypes,
 	/**
-	 * Fires a 'Union Type' track call.
+	 * Validates that clients support fields with multiple (union) types.
 	 *
 	 * @param {UnionType} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1678,7 +1817,7 @@ const clientAPI = {
 	 */
 	unionType,
 	/**
-	 * Fires a 'event_collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.

--- a/tests/e2e/web-javascript/analytics/plan.json
+++ b/tests/e2e/web-javascript/analytics/plan.json
@@ -62,6 +62,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.",
         "name": "Custom Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -89,6 +90,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.",
         "name": "Custom Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -107,6 +109,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.",
         "name": "Default Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -134,6 +137,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.",
         "name": "Default Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -152,6 +156,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.",
         "name": "Empty Event",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -170,6 +175,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "Event Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -188,6 +194,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.",
         "name": "Every Nullable Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -239,6 +246,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.",
         "name": "Every Nullable Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -301,6 +309,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as optional fields.",
         "name": "Every Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -353,6 +362,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as required fields. ",
         "name": "Every Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +426,67 @@
         "version": 1
       },
       {
+        "description": "Validates that clients correctly serialize large numbers (integers and floats).",
+        "name": "Large Numbers Event",
+        "rules": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "labels": {},
+          "properties": {
+            "context": {},
+            "properties": {
+              "properties": {
+                "large nullable optional integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable optional number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large nullable required integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable required number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large optional integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large optional number": {
+                  "description": "",
+                  "type": "number"
+                },
+                "large required integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large required number": {
+                  "description": "",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "large required integer",
+                "large required number",
+                "large nullable required integer",
+                "large nullable required number"
+              ],
+              "type": "object"
+            },
+            "traits": {
+              "type": "object"
+            }
+          },
+          "required": ["properties"],
+          "type": "object"
+        },
+        "version": 1
+      },
+      {
+        "description": "Validates that clients handle arrays-within-arrays.",
         "name": "Nested Arrays",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -457,6 +528,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle objects-within-objects.",
         "name": "Nested Objects",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -512,6 +584,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in property names within a single event.",
         "name": "Properties Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -542,6 +615,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #1",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -588,6 +662,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #2",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -634,6 +709,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients sanitize property names that contain invalid identifier characters.",
         "name": "Property Sanitized",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -660,6 +736,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with various types of arrays.",
         "name": "Simple Array Types",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -742,6 +819,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with multiple (union) types.",
         "name": "Union Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -768,6 +846,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "event_collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,5 +868,5 @@
     "group_traits": [],
     "identify_traits": []
   },
-  "update_time": "2019-10-16T23:36:31.000Z"
+  "update_time": "2019-11-15T17:43:14.000Z"
 }

--- a/tests/e2e/web-javascript/pages/index.jsx
+++ b/tests/e2e/web-javascript/pages/index.jsx
@@ -22,6 +22,7 @@ import typewriter, {
 	customViolationHandler,
 	customViolationHandlerCalled,
 	propertySanitized,
+	largeNumbersEvent,
 } from '../analytics'
 
 export default class HomePage extends React.Component {
@@ -191,6 +192,17 @@ export default class HomePage extends React.Component {
 		// because the regex will not match.
 		customViolationHandler({
 			'regex property': 'Not a Real Morty',
+		})
+
+		largeNumbersEvent({
+			'large nullable optional integer': 1230007112658965944,
+			'large nullable optional number': 1240007112658965944331.0,
+			'large nullable required integer': 1250007112658965944,
+			'large nullable required number': 1260007112658965944331.0,
+			'large optional integer': 1270007112658965944,
+			'large optional number': 1280007112658965944331.0,
+			'large required integer': 1290007112658965944,
+			'large required number': 1300007112658965944331.0,
 		})
 
 		// There is no generated function for `aMissingAnalyticsCall`, but the JS Proxy should

--- a/tests/e2e/web-typescript/analytics/index.ts
+++ b/tests/e2e/web-typescript/analytics/index.ts
@@ -155,6 +155,16 @@ export interface EveryRequiredType {
 	 */
 	'required string with regex': string
 }
+export interface LargeNumbersEvent {
+	'large nullable optional integer'?: number | null
+	'large nullable optional number'?: number | null
+	'large nullable required integer': number | null
+	'large nullable required number': number | null
+	'large optional integer'?: number
+	'large optional number'?: number
+	'large required integer': number
+	'large required number': number
+}
 export interface UniverseCharactersItemItem {
 	/**
 	 * The character's name.
@@ -399,6 +409,17 @@ function withTypewriterContext(message: Segment.Options = {}): Segment.Options {
  * @property {string} required string with regex - Required string property with a regex conditional
  */
 /**
+ * @typedef LargeNumbersEvent
+ * @property {number | null} [large nullable optional integer] -
+ * @property {number | null} [large nullable optional number] -
+ * @property {number | null} large nullable required integer -
+ * @property {number | null} large nullable required number -
+ * @property {number} [large optional integer] -
+ * @property {number} [large optional number] -
+ * @property {number} large required integer -
+ * @property {number} large required number -
+ */
+/**
  * @typedef UniverseCharactersItemItem
  * @property {string} name - The character's name.
  */
@@ -619,7 +640,7 @@ export function analyticsInstanceMissingThrewError(
 	}
 }
 /**
- * Fires a 'Custom Violation Handler' track call.
+ * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
  *
  * @param {CustomViolationHandler} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -633,6 +654,8 @@ export function customViolationHandler(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -673,7 +696,7 @@ export function customViolationHandler(
 	}
 }
 /**
- * Fires a 'Custom Violation Handler Called' track call.
+ * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -687,6 +710,8 @@ export function customViolationHandlerCalled(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -718,7 +743,7 @@ export function customViolationHandlerCalled(
 	}
 }
 /**
- * Fires a 'Default Violation Handler' track call.
+ * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
  *
  * @param {DefaultViolationHandler} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -732,6 +757,8 @@ export function defaultViolationHandler(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -772,7 +799,7 @@ export function defaultViolationHandler(
 	}
 }
 /**
- * Fires a 'Default Violation Handler Called' track call.
+ * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -786,6 +813,8 @@ export function defaultViolationHandlerCalled(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.',
 		labels: {},
 		properties: {
 			context: {},
@@ -817,7 +846,7 @@ export function defaultViolationHandlerCalled(
 	}
 }
 /**
- * Fires a 'Empty Event' track call.
+ * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -831,6 +860,8 @@ export function emptyEvent(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.',
 		labels: {},
 		properties: {
 			context: {},
@@ -862,7 +893,7 @@ export function emptyEvent(
 	}
 }
 /**
- * Fires a 'Event Collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -876,6 +907,8 @@ export function eventCollided(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -907,7 +940,7 @@ export function eventCollided(
 	}
 }
 /**
- * Fires a 'Every Nullable Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
  *
  * @param {EveryNullableOptionalType} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -921,6 +954,8 @@ export function everyNullableOptionalType(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -985,7 +1020,7 @@ export function everyNullableOptionalType(
 	}
 }
 /**
- * Fires a 'Every Nullable Required Type' track call.
+ * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
  *
  * @param {EveryNullableRequiredType} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -999,6 +1034,8 @@ export function everyNullableRequiredType(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.',
 		properties: {
 			context: {},
 			properties: {
@@ -1074,7 +1111,7 @@ export function everyNullableRequiredType(
 	}
 }
 /**
- * Fires a 'Every Optional Type' track call.
+ * Validates that clients handle all of the supported field types, as optional fields.
  *
  * @param {EveryOptionalType} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1088,6 +1125,8 @@ export function everyOptionalType(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as optional fields.',
 		properties: {
 			context: {},
 			properties: {
@@ -1153,7 +1192,7 @@ export function everyOptionalType(
 	}
 }
 /**
- * Fires a 'Every Required Type' track call.
+ * Validates that clients handle all of the supported field types, as required fields.
  *
  * @param {EveryRequiredType} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1167,6 +1206,8 @@ export function everyRequiredType(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle all of the supported field types, as required fields. ',
 		properties: {
 			context: {},
 			properties: {
@@ -1243,7 +1284,95 @@ export function everyRequiredType(
 	}
 }
 /**
- * Fires a 'Nested Arrays' track call.
+ * Validates that clients correctly serialize large numbers (integers and floats).
+ *
+ * @param {LargeNumbersEvent} props - The analytics properties that will be sent to Segment.
+ * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+ * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+ * 		call is fired.
+ */
+export function largeNumbersEvent(
+	props: LargeNumbersEvent,
+	options?: Segment.Options,
+	callback?: Segment.Callback
+): void {
+	const schema = {
+		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients correctly serialize large numbers (integers and floats).',
+		labels: {},
+		properties: {
+			context: {},
+			properties: {
+				properties: {
+					'large nullable optional integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable optional number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large nullable required integer': {
+						description: '',
+						type: ['integer', 'null'],
+					},
+					'large nullable required number': {
+						description: '',
+						type: ['number', 'null'],
+					},
+					'large optional integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large optional number': {
+						description: '',
+						type: 'number',
+					},
+					'large required integer': {
+						description: '',
+						type: 'integer',
+					},
+					'large required number': {
+						description: '',
+						type: 'number',
+					},
+				},
+				required: [
+					'large required integer',
+					'large required number',
+					'large nullable required integer',
+					'large nullable required number',
+				],
+				type: 'object',
+			},
+			traits: {
+				type: 'object',
+			},
+		},
+		required: ['properties'],
+		title: 'Large Numbers Event',
+		type: 'object',
+	}
+	const message = {
+		event: 'Large Numbers Event',
+		properties: props || {},
+		options,
+	}
+	validateAgainstSchema(message, schema)
+
+	const a = analytics()
+	if (a) {
+		a.track(
+			'Large Numbers Event',
+			props || {},
+			withTypewriterContext(options),
+			callback
+		)
+	}
+}
+/**
+ * Validates that clients handle arrays-within-arrays.
  *
  * @param {NestedArrays} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1257,6 +1386,7 @@ export function nestedArrays(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle arrays-within-arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1311,7 +1441,7 @@ export function nestedArrays(
 	}
 }
 /**
- * Fires a 'Nested Objects' track call.
+ * Validates that clients handle objects-within-objects.
  *
  * @param {NestedObjects} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1325,6 +1455,7 @@ export function nestedObjects(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description: 'Validates that clients handle objects-within-objects.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1393,7 +1524,7 @@ export function nestedObjects(
 	}
 }
 /**
- * Fires a 'Properties Collided' track call.
+ * Validates that clients handle collisions in property names within a single event.
  *
  * @param {PropertiesCollided} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1407,6 +1538,8 @@ export function propertiesCollided(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in property names within a single event.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1450,7 +1583,7 @@ export function propertiesCollided(
 	}
 }
 /**
- * Fires a 'Property Object Name Collision #1' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {PropertyObjectNameCollision1} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1464,6 +1597,8 @@ export function propertyObjectNameCollision1(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1523,7 +1658,7 @@ export function propertyObjectNameCollision1(
 	}
 }
 /**
- * Fires a 'Property Object Name Collision #2' track call.
+ * Validates that clients handle collisions in object names across multiple events.
  *
  * @param {PropertyObjectNameCollision2} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1537,6 +1672,8 @@ export function propertyObjectNameCollision2(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients handle collisions in object names across multiple events.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1596,7 +1733,7 @@ export function propertyObjectNameCollision2(
 	}
 }
 /**
- * Fires a 'Property Sanitized' track call.
+ * Validates that clients sanitize property names that contain invalid identifier characters.
  *
  * @param {PropertySanitized} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1610,6 +1747,8 @@ export function propertySanitized(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients sanitize property names that contain invalid identifier characters.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1649,7 +1788,7 @@ export function propertySanitized(
 	}
 }
 /**
- * Fires a 'Simple Array Types' track call.
+ * Validates that clients support fields with various types of arrays.
  *
  * @param {SimpleArrayTypes} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1663,6 +1802,8 @@ export function simpleArrayTypes(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with various types of arrays.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1758,7 +1899,7 @@ export function simpleArrayTypes(
 	}
 }
 /**
- * Fires a 'Union Type' track call.
+ * Validates that clients support fields with multiple (union) types.
  *
  * @param {UnionType} props - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1772,6 +1913,8 @@ export function unionType(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that clients support fields with multiple (union) types.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1806,7 +1949,7 @@ export function unionType(
 	}
 }
 /**
- * Fires a 'event_collided' track call.
+ * Validates that a generated client handles even naming collisions.
  *
  * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
  * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1820,6 +1963,8 @@ export function eventCollided1(
 ): void {
 	const schema = {
 		$schema: 'http://json-schema.org/draft-07/schema#',
+		description:
+			'Validates that a generated client handles even naming collisions.',
 		labels: {},
 		properties: {
 			context: {},
@@ -1894,7 +2039,7 @@ const clientAPI = {
 	 */
 	analyticsInstanceMissingThrewError,
 	/**
-	 * Fires a 'Custom Violation Handler' track call.
+	 * This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {CustomViolationHandler} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1903,7 +2048,7 @@ const clientAPI = {
 	 */
 	customViolationHandler,
 	/**
-	 * Fires a 'Custom Violation Handler Called' track call.
+	 * This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1912,7 +2057,7 @@ const clientAPI = {
 	 */
 	customViolationHandlerCalled,
 	/**
-	 * Fires a 'Default Violation Handler' track call.
+	 * This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.
 	 *
 	 * @param {DefaultViolationHandler} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1921,7 +2066,7 @@ const clientAPI = {
 	 */
 	defaultViolationHandler,
 	/**
-	 * Fires a 'Default Violation Handler Called' track call.
+	 * This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1930,7 +2075,7 @@ const clientAPI = {
 	 */
 	defaultViolationHandlerCalled,
 	/**
-	 * Fires a 'Empty Event' track call.
+	 * Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1939,7 +2084,7 @@ const clientAPI = {
 	 */
 	emptyEvent,
 	/**
-	 * Fires a 'Event Collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1948,7 +2093,7 @@ const clientAPI = {
 	 */
 	eventCollided,
 	/**
-	 * Fires a 'Every Nullable Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.
 	 *
 	 * @param {EveryNullableOptionalType} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1957,7 +2102,7 @@ const clientAPI = {
 	 */
 	everyNullableOptionalType,
 	/**
-	 * Fires a 'Every Nullable Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.
 	 *
 	 * @param {EveryNullableRequiredType} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1966,7 +2111,7 @@ const clientAPI = {
 	 */
 	everyNullableRequiredType,
 	/**
-	 * Fires a 'Every Optional Type' track call.
+	 * Validates that clients handle all of the supported field types, as optional fields.
 	 *
 	 * @param {EveryOptionalType} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1975,7 +2120,7 @@ const clientAPI = {
 	 */
 	everyOptionalType,
 	/**
-	 * Fires a 'Every Required Type' track call.
+	 * Validates that clients handle all of the supported field types, as required fields.
 	 *
 	 * @param {EveryRequiredType} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1984,7 +2129,16 @@ const clientAPI = {
 	 */
 	everyRequiredType,
 	/**
-	 * Fires a 'Nested Arrays' track call.
+	 * Validates that clients correctly serialize large numbers (integers and floats).
+	 *
+	 * @param {LargeNumbersEvent} props - The analytics properties that will be sent to Segment.
+	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
+	 * @param {Function} [callback] - An optional callback called after a short timeout after the analytics
+	 * 		call is fired.
+	 */
+	largeNumbersEvent,
+	/**
+	 * Validates that clients handle arrays-within-arrays.
 	 *
 	 * @param {NestedArrays} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -1993,7 +2147,7 @@ const clientAPI = {
 	 */
 	nestedArrays,
 	/**
-	 * Fires a 'Nested Objects' track call.
+	 * Validates that clients handle objects-within-objects.
 	 *
 	 * @param {NestedObjects} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2002,7 +2156,7 @@ const clientAPI = {
 	 */
 	nestedObjects,
 	/**
-	 * Fires a 'Properties Collided' track call.
+	 * Validates that clients handle collisions in property names within a single event.
 	 *
 	 * @param {PropertiesCollided} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2011,7 +2165,7 @@ const clientAPI = {
 	 */
 	propertiesCollided,
 	/**
-	 * Fires a 'Property Object Name Collision #1' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {PropertyObjectNameCollision1} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2020,7 +2174,7 @@ const clientAPI = {
 	 */
 	propertyObjectNameCollision1,
 	/**
-	 * Fires a 'Property Object Name Collision #2' track call.
+	 * Validates that clients handle collisions in object names across multiple events.
 	 *
 	 * @param {PropertyObjectNameCollision2} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2029,7 +2183,7 @@ const clientAPI = {
 	 */
 	propertyObjectNameCollision2,
 	/**
-	 * Fires a 'Property Sanitized' track call.
+	 * Validates that clients sanitize property names that contain invalid identifier characters.
 	 *
 	 * @param {PropertySanitized} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2038,7 +2192,7 @@ const clientAPI = {
 	 */
 	propertySanitized,
 	/**
-	 * Fires a 'Simple Array Types' track call.
+	 * Validates that clients support fields with various types of arrays.
 	 *
 	 * @param {SimpleArrayTypes} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2047,7 +2201,7 @@ const clientAPI = {
 	 */
 	simpleArrayTypes,
 	/**
-	 * Fires a 'Union Type' track call.
+	 * Validates that clients support fields with multiple (union) types.
 	 *
 	 * @param {UnionType} props - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.
@@ -2056,7 +2210,7 @@ const clientAPI = {
 	 */
 	unionType,
 	/**
-	 * Fires a 'event_collided' track call.
+	 * Validates that a generated client handles even naming collisions.
 	 *
 	 * @param {Record<string, any>} [props] - The analytics properties that will be sent to Segment.
 	 * @param {Object} [options] - A dictionary of options. For example, enable or disable specific destinations for the call.

--- a/tests/e2e/web-typescript/analytics/plan.json
+++ b/tests/e2e/web-typescript/analytics/plan.json
@@ -62,6 +62,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.",
         "name": "Custom Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -89,6 +90,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if a custom violation handler is correctly called due to a call to `Custom Violation Handler` with a violation.",
         "name": "Custom Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -107,6 +109,7 @@
         "version": 1
       },
       {
+        "description": "This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.",
         "name": "Default Violation Handler",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -134,6 +137,7 @@
         "version": 1
       },
       {
+        "description": "This event should be fired if the default violation handler is correctly called due to a call to `Default Violation Handler` with a violation.",
         "name": "Default Violation Handler Called",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -152,6 +156,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client supports events with no explicit properties. It is expected that this event accepts ANY properties.",
         "name": "Empty Event",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -170,6 +175,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "Event Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -188,6 +194,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.",
         "name": "Every Nullable Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -239,6 +246,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.",
         "name": "Every Nullable Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -301,6 +309,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as optional fields.",
         "name": "Every Optional Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -353,6 +362,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle all of the supported field types, as required fields. ",
         "name": "Every Required Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -416,6 +426,67 @@
         "version": 1
       },
       {
+        "description": "Validates that clients correctly serialize large numbers (integers and floats).",
+        "name": "Large Numbers Event",
+        "rules": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "labels": {},
+          "properties": {
+            "context": {},
+            "properties": {
+              "properties": {
+                "large nullable optional integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable optional number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large nullable required integer": {
+                  "description": "",
+                  "type": ["integer", "null"]
+                },
+                "large nullable required number": {
+                  "description": "",
+                  "type": ["number", "null"]
+                },
+                "large optional integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large optional number": {
+                  "description": "",
+                  "type": "number"
+                },
+                "large required integer": {
+                  "description": "",
+                  "type": "integer"
+                },
+                "large required number": {
+                  "description": "",
+                  "type": "number"
+                }
+              },
+              "required": [
+                "large required integer",
+                "large required number",
+                "large nullable required integer",
+                "large nullable required number"
+              ],
+              "type": "object"
+            },
+            "traits": {
+              "type": "object"
+            }
+          },
+          "required": ["properties"],
+          "type": "object"
+        },
+        "version": 1
+      },
+      {
+        "description": "Validates that clients handle arrays-within-arrays.",
         "name": "Nested Arrays",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -457,6 +528,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle objects-within-objects.",
         "name": "Nested Objects",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -512,6 +584,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in property names within a single event.",
         "name": "Properties Collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -542,6 +615,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #1",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -588,6 +662,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients handle collisions in object names across multiple events.",
         "name": "Property Object Name Collision #2",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -634,6 +709,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients sanitize property names that contain invalid identifier characters.",
         "name": "Property Sanitized",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -660,6 +736,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with various types of arrays.",
         "name": "Simple Array Types",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -742,6 +819,7 @@
         "version": 1
       },
       {
+        "description": "Validates that clients support fields with multiple (union) types.",
         "name": "Union Type",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -768,6 +846,7 @@
         "version": 1
       },
       {
+        "description": "Validates that a generated client handles even naming collisions.",
         "name": "event_collided",
         "rules": {
           "$schema": "http://json-schema.org/draft-07/schema#",
@@ -789,5 +868,5 @@
     "group_traits": [],
     "identify_traits": []
   },
-  "update_time": "2019-10-16T23:36:31.000Z"
+  "update_time": "2019-11-15T17:43:14.000Z"
 }

--- a/tests/e2e/web-typescript/pages/index.tsx
+++ b/tests/e2e/web-typescript/pages/index.tsx
@@ -22,6 +22,7 @@ import typewriter, {
 	customViolationHandler,
 	customViolationHandlerCalled,
 	propertySanitized,
+	largeNumbersEvent,
 } from '../analytics'
 
 export default class HomePage extends React.Component {
@@ -200,5 +201,16 @@ export default class HomePage extends React.Component {
 		// There is no generated function for `aMissingAnalyticsCall`, but the JS Proxy should
 		// handle this and avoid a crash.
 		typewriterWithoutTypes.aMissingAnalyticsCall()
+
+		largeNumbersEvent({
+			'large nullable optional integer': 1230007112658965944,
+			'large nullable optional number': 1240007112658965944331.0,
+			'large nullable required integer': 1250007112658965944,
+			'large nullable required number': 1260007112658965944331.0,
+			'large optional integer': 1270007112658965944,
+			'large optional number': 1280007112658965944331.0,
+			'large required integer': 1290007112658965944,
+			'large required number': 1300007112658965944331.0,
+		})
 	}
 }


### PR DESCRIPTION
This PR adds a test to catch a regression we saw in our Swift client in v6 of typewriter, where an incorrect memory attribute led to corruption during serialization: https://github.com/segmentio/typewriter/pull/61/files

---

While adding this test, I noticed our iOS clients generate `NSInteger *` which is just a pointer to a primitive `int` under-the-hood. This PR updates the generator to instead us an `NSNumber *` for nullable and optional integers.