### PR TITLE
Speed up iOS Tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,17 +133,19 @@ jobs:
           command: date +%m-%d-%Y > .ci-date
       - restore_cache:
           keys:
-            - v1-cocoapods-{{ checksum ".ci-date" }}
+            - v7-cocoapods-{{ checksum ".ci-date" }}
       - run:
           name: Fetch Cocoapods specs
           command: |
-            # Don't bother syncing if a cocoapods directory was found in the cache.
-            [ -e .cocoapods ] && exit 0
-            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
+            pwd
+            ls -la
+            ls -la ..
+            ls -la ../.cocoapods
+            [ -e ../.cocoapods/repos ] || curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
       - save_cache:
           paths:
-            - .cocoapods
-          key: v1-cocoapods-{{ checksum ".ci-date" }}
+            - ../.cocoapods/repos
+          key: v7-cocoapods-{{ checksum ".ci-date" }}
       - run:
           name: Run iOS Swift Tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,21 @@ jobs:
             sudo gem install xcpretty
             sudo gem install cocoapods -v $(var=$(tail -1 tests/e2e/ios-objc/Podfile.lock); echo ${var##COCOAPODS:})
       - run:
+          name: Save cache key (date)
+          command: date +%m-%d-%Y > .ci-date
+      - restore_cache:
+          keys:
+            - v1-cocoapods-{{ checksum ".ci-date" }}
+      - run:
           name: Fetch Cocoapods specs
-          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+          command: |
+            # Don't bother syncing if a cocoapods directory was found in the cache.
+            [ -e .cocoapods ] && exit 0
+            curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash
+      - save_cache:
+          paths:
+            - .cocoapods
+          key: v1-cocoapods-{{ checksum ".ci-date" }}
       - run:
           name: Run iOS Swift Tests
           command: |

--- a/fetch-cocoapods-repo-from-s3.sh
+++ b/fetch-cocoapods-repo-from-s3.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+REPOS_LOCATION="$HOME/.cocoapods/repos"
+MASTER_REPO_LOCATION="$REPOS_LOCATION/master"
+S3_BUCKET="cocoapods-specs"
+CF_LOCATION="https://cocoapods-specs.circleci.com"
+
+tempfile=$(mktemp)
+
+cleanup() {
+  echo "Download from S3 failed, cleaning up and falling back to standard checkout..."
+  rm -rf "$MASTER_REPO_LOCATION"
+  rm "$tempfile"
+}
+
+trap cleanup ERR
+
+rm -rf "$MASTER_REPO_LOCATION"
+mkdir -p "$REPOS_LOCATION"
+
+if [[ "${1:-}" == "cf" ]] ; then
+  echo "Downloading CocoaPods master repo from $CF_LOCATION..."
+  # no progress bar at all, but show errors
+  curl -sS -L -o "$tempfile" "$CF_LOCATION/latest.tar.gz"
+else
+  # Only install awscli if it's not in the image. pip will exit with
+  # non-zero exit code if the package is not installed. Hiding all output
+  # from package installation to not to confuse users.
+  if ! pip show awscli > /dev/null 2>&1 ; then
+    sudo pip install --ignore-installed awscli > /dev/null 2>&1
+  fi
+
+  echo "Downloading CocoaPods master repo from $S3_BUCKET S3 bucket..."
+  # --no-sign-request forces awscli to not to use any credentials.
+  aws s3 --no-sign-request cp "s3://$S3_BUCKET/latest.tar.gz" "$tempfile" > /dev/null
+fi
+
+echo "Uncompressing CocoaPods master repo..."
+# We expect the structure with the "master" as the top dir in the archive.
+tar -C "$REPOS_LOCATION" -xzf "$tempfile"
+
+echo "Successfully downloaded CocoaPods master repo."
+COCOAPODS_GIT_REV="$(cd $MASTER_REPO_LOCATION && git rev-parse HEAD)"
+echo "Using specs repo revision $COCOAPODS_GIT_REV."
+
+rm "$tempfile"


### PR DESCRIPTION
Resolves: https://github.com/segmentio/typewriter/issues/99

This PR:
- Caches the cocoapods repos, pulling from the official CircleCI cocoapods cache only once per day
- Switches the cache from cocoapods's mirror to S3 (removes `cf`)
- Disabled unnecessary Snyk tests on examples/e2e tests