### PR TITLE
[CI] Run dev and prod CI tests in parallel (~15% faster)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,37 +53,65 @@ jobs:
       - attach_workspace: { at: . }
       - run: make build-example
 
-  test-node-javascript:
+  test-node-javascript-dev:
     docker:
       - image: circleci/node:10.15
       - image: segment/mock:v0.0.2
     steps:
       - attach_workspace: { at: . }
-      - run: make test-node-javascript
-  test-node-typescript:
+      - run: make test-node-javascript-dev
+  test-node-javascript-prod:
     docker:
       - image: circleci/node:10.15
       - image: segment/mock:v0.0.2
     steps:
       - attach_workspace: { at: . }
-      - run: make test-node-typescript
+      - run: make test-node-javascript-prod
+  test-node-typescript-dev:
+    docker:
+      - image: circleci/node:10.15
+      - image: segment/mock:v0.0.2
+    steps:
+      - attach_workspace: { at: . }
+      - run: make test-node-typescript-dev
+  test-node-typescript-prod:
+    docker:
+      - image: circleci/node:10.15
+      - image: segment/mock:v0.0.2
+    steps:
+      - attach_workspace: { at: . }
+      - run: make test-node-typescript-prod
 
-  test-web-javascript:
+  test-web-javascript-dev:
     docker:
       - image: cypress/browsers:chrome69
       - image: segment/mock:v0.0.2
     steps:
       - attach_workspace: { at: . }
-      - run: make test-web-javascript
-  test-web-typescript:
+      - run: make test-web-javascript-dev
+  test-web-javascript-prod:
     docker:
       - image: cypress/browsers:chrome69
       - image: segment/mock:v0.0.2
     steps:
       - attach_workspace: { at: . }
-      - run: make test-web-typescript
+      - run: make test-web-javascript-prod
+  test-web-typescript-dev:
+    docker:
+      - image: cypress/browsers:chrome69
+      - image: segment/mock:v0.0.2
+    steps:
+      - attach_workspace: { at: . }
+      - run: make test-web-typescript-dev
+  test-web-typescript-prod:
+    docker:
+      - image: cypress/browsers:chrome69
+      - image: segment/mock:v0.0.2
+    steps:
+      - attach_workspace: { at: . }
+      - run: make test-web-typescript-prod
 
-  test-ios-objc:
+  test-ios-objc-dev:
     macos:
       xcode: "11.0.0"
     steps:
@@ -106,9 +134,32 @@ jobs:
             yarn dev &
             cd ..
             sleep 5
-            make test-ios-objc
-
-  test-ios-swift:
+            make test-ios-objc-dev
+  test-ios-objc-prod:
+    macos:
+      xcode: "11.0.0"
+    steps:
+      - attach_workspace: { at: . }
+      - run: xcrun simctl list
+      - run:
+          name: Install build dependencies
+          command: |
+            sudo gem install xcpretty
+            sudo gem install cocoapods -v $(var=$(tail -1 tests/e2e/ios-objc/Podfile.lock); echo ${var##COCOAPODS:})
+      - run:
+          name: Fetch Cocoapods specs
+          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: Run iOS Objective-C Tests
+          command: |
+            git clone https://github.com/segmentio/mock.git
+            cd mock
+            yarn
+            yarn dev &
+            cd ..
+            sleep 5
+            make test-ios-objc-prod
+  test-ios-swift-dev:
     macos:
       xcode: "11.0.0"
     steps:
@@ -131,7 +182,31 @@ jobs:
             yarn dev &
             cd ..
             sleep 5
-            make test-ios-swift
+            make test-ios-swift-dev
+  test-ios-swift-prod:
+    macos:
+      xcode: "11.0.0"
+    steps:
+      - attach_workspace: { at: . }
+      - run: xcrun simctl list
+      - run:
+          name: Install build dependencies
+          command: |
+            sudo gem install xcpretty
+            sudo gem install cocoapods -v $(var=$(tail -1 tests/e2e/ios-objc/Podfile.lock); echo ${var##COCOAPODS:})
+      - run:
+          name: Fetch Cocoapods specs
+          command: curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+      - run:
+          name: Run iOS Swift Tests
+          command: |
+            git clone https://github.com/segmentio/mock.git
+            cd mock
+            yarn
+            yarn dev &
+            cd ..
+            sleep 5
+            make test-ios-swift-prod
 
 workflows:
   version: 2
@@ -146,15 +221,27 @@ workflows:
           requires: [setup]
       - test-unit-tests:
           requires: [setup]
-      - test-node-javascript:
+      - test-node-javascript-dev:
           requires: [setup]
-      - test-node-typescript:
+      - test-node-javascript-prod:
           requires: [setup]
-      - test-web-javascript:
+      - test-node-typescript-dev:
           requires: [setup]
-      - test-web-typescript:
+      - test-node-typescript-prod:
           requires: [setup]
-      - test-ios-objc:
+      - test-web-javascript-dev:
           requires: [setup]
-      - test-ios-swift:
+      - test-web-javascript-prod:
+          requires: [setup]
+      - test-web-typescript-dev:
+          requires: [setup]
+      - test-web-typescript-prod:
+          requires: [setup]
+      - test-ios-objc-dev:
+          requires: [setup]
+      - test-ios-objc-prod:
+          requires: [setup]
+      - test-ios-swift-dev:
+          requires: [setup]
+      - test-ios-swift-prod:
           requires: [setup]

--- a/Makefile
+++ b/Makefile
@@ -84,8 +84,11 @@ build-example:
 		yarn build
 
 .PHONY: test-node-javascript
-test-node-javascript:
-	@echo "\n>>>	🏃 Running JavaScript Node client test suite...\n"
+test-node-javascript: test-node-javascript-dev test-node-javascript-prod
+
+.PHONY: test-node-javascript-dev
+test-node-javascript-dev:
+	@echo "\n>>>	🏃 Running dev JavaScript Node client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev build --config=./tests/e2e/node-javascript && \
 		cd tests/e2e/node-javascript && \
@@ -93,6 +96,10 @@ test-node-javascript:
 		NODE_ENV=test yarn run -s test && \
 		cd ../../.. && \
 		SDK=analytics-node LANGUAGE=javascript IS_DEVELOPMENT=true yarn run -s jest ./tests/e2e/suite.test.ts
+
+.PHONY: test-node-javascript-prod
+test-node-javascript-prod:
+	@echo "\n>>>	🏃 Running prod JavaScript Node client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev prod --config=./tests/e2e/node-javascript && \
 		cd tests/e2e/node-javascript && \
@@ -102,8 +109,11 @@ test-node-javascript:
 		SDK=analytics-node LANGUAGE=javascript IS_DEVELOPMENT=false yarn run -s jest ./tests/e2e/suite.test.ts
 
 .PHONY: test-node-typescript
-test-node-typescript:
-	@echo "\n>>>	🏃 Running TypeScript Node client test suite...\n"
+test-node-typescript: test-node-typescript-dev test-node-typescript-prod
+
+.PHONY: test-node-typescript-dev
+test-node-typescript-dev:
+	@echo "\n>>>	🏃 Running dev TypeScript Node client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev build --config=./tests/e2e/node-typescript && \
 		cd tests/e2e/node-typescript && \
@@ -111,6 +121,10 @@ test-node-typescript:
 		NODE_ENV=test yarn run -s test && \
 		cd ../../.. && \
 		SDK=analytics-node LANGUAGE=typescript IS_DEVELOPMENT=true yarn run -s jest ./tests/e2e/suite.test.ts
+
+.PHONY: test-node-typescript-prod
+test-node-typescript-prod:
+	@echo "\n>>>	🏃 Running prod TypeScript Node client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev prod --config=./tests/e2e/node-typescript && \
 		cd tests/e2e/node-typescript && \
@@ -120,8 +134,11 @@ test-node-typescript:
 		SDK=analytics-node LANGUAGE=typescript IS_DEVELOPMENT=false yarn run -s jest ./tests/e2e/suite.test.ts
 
 .PHONY: test-web-javascript
-test-web-javascript:
-	@echo "\n>>>	🏃 Running JavaScript analytics.js client test suite...\n"
+test-web-javascript: test-web-javascript-dev test-web-javascript-prod
+
+.PHONY: test-web-javascript-dev
+test-web-javascript-dev:
+	@echo "\n>>>	🏃 Running dev JavaScript analytics.js client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev build --config=./tests/e2e/web-javascript && \
 		cd tests/e2e/web-javascript && \
@@ -130,6 +147,10 @@ test-web-javascript:
 		NODE_ENV=test yarn run -s test && \
 		cd ../../.. && \
 		SDK=analytics.js LANGUAGE=javascript IS_DEVELOPMENT=true yarn run -s jest ./tests/e2e/suite.test.ts
+
+.PHONY: test-web-javascript-prod
+test-web-javascript-prod:
+	@echo "\n>>>	🏃 Running prod JavaScript analytics.js client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev prod --config=./tests/e2e/web-javascript && \
 		cd tests/e2e/web-javascript && \
@@ -140,8 +161,11 @@ test-web-javascript:
 		SDK=analytics.js LANGUAGE=javascript IS_DEVELOPMENT=false yarn run -s jest ./tests/e2e/suite.test.ts
 
 .PHONY: test-web-typescript
-test-web-typescript:
-	@echo "\n>>>	🏃 Running TypeScript analytics.js client test suite...\n"
+test-web-typescript: test-web-typescript-dev test-web-typescript-prod
+
+.PHONY: test-web-typescript-dev
+test-web-typescript-dev:
+	@echo "\n>>>	🏃 Running dev TypeScript analytics.js client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev build --config=./tests/e2e/web-typescript && \
 		cd tests/e2e/web-typescript && \
@@ -150,6 +174,10 @@ test-web-typescript:
 		NODE_ENV=test yarn run -s test && \
 		cd ../../.. && \
 		SDK=analytics.js LANGUAGE=typescript IS_DEVELOPMENT=true yarn run -s jest ./tests/e2e/suite.test.ts
+	
+.PHONY: test-web-typescript-prod
+test-web-typescript-prod:
+	@echo "\n>>>	🏃 Running prod TypeScript analytics.js client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev prod --config=./tests/e2e/web-typescript && \
 		cd tests/e2e/web-typescript && \
@@ -159,48 +187,54 @@ test-web-typescript:
 		cd ../../.. && \
 		SDK=analytics.js LANGUAGE=typescript IS_DEVELOPMENT=false yarn run -s jest ./tests/e2e/suite.test.ts
 
-# We split up test-ios-objc in order for CI to cache the setup step.
 .PHONY: test-ios-objc
-test-ios-objc: setup-ios-objc-tests run-ios-objc-tests
+test-ios-objc: test-ios-objc-dev test-ios-objc-prod
 
-.PHONY: setup-ios-objc-tests
-setup-ios-objc-tests:
+.PHONY: test-ios-objc-dev
+test-ios-objc-dev:
+	@echo "\n>>>	🏃 Running dev iOS Objective-C client test suite...\n"
 	@# TODO: verify that xcodebuild and xcpretty are available
 	@cd tests/e2e/ios-objc && \
 		pod install
-
-.PHONY: run-ios-objc-tests
-run-ios-objc-tests:
-	@echo "\n>>>	🏃 Running iOS Objective-C client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev build --config=./tests/e2e/ios-objc && \
 		cd tests/e2e/ios-objc && \
 		set -o pipefail && xcodebuild test $(XC_OBJECTIVE_C_ARGS) | xcpretty && \
 		SDK=analytics-ios LANGUAGE=objective-c IS_DEVELOPMENT=true yarn run -s jest ./tests/e2e/suite.test.ts
+
+.PHONY: test-ios-objc-prod
+test-ios-objc-prod:
+	@echo "\n>>>	🏃 Running prod iOS Objective-C client test suite...\n"
+	@# TODO: verify that xcodebuild and xcpretty are available
+	@cd tests/e2e/ios-objc && \
+		pod install
 	@make clear-mock && \
 		yarn run -s dev prod --config=./tests/e2e/ios-objc && \
 		cd tests/e2e/ios-objc && \
 		set -o pipefail && xcodebuild test $(XC_OBJECTIVE_C_ARGS) | xcpretty && \
 		SDK=analytics-ios LANGUAGE=objective-c IS_DEVELOPMENT=false yarn run -s jest ./tests/e2e/suite.test.ts
 
-# We split up test-ios in order for CI to cache the setup step.
 .PHONY: test-ios-swift
-test-ios-swift: setup-ios-swift-tests run-ios-swift-tests
+test-ios-swift: test-ios-swift-dev test-ios-swift-prod
 
-.PHONY: setup-ios-swift-tests
-setup-ios-swift-tests:
+.PHONY: test-ios-swift-dev
+test-ios-swift-dev:
+	@echo "\n>>>	🏃 Running dev iOS Swift client test suite...\n"
 	@# TODO: verify that xcodebuild and xcpretty are available
 	@cd tests/e2e/ios-swift && \
 		pod install
-
-.PHONY: run-ios-swift-tests
-run-ios-swift-tests:
-	@echo "\n>>>	🏃 Running iOS Swift client test suite...\n"
 	@make clear-mock && \
 		yarn run -s dev build --config=./tests/e2e/ios-swift && \
 		cd tests/e2e/ios-swift && \
 		set -o pipefail && xcodebuild test $(XC_SWIFT_ARGS) | xcpretty && \
 		SDK=analytics-ios LANGUAGE=swift IS_DEVELOPMENT=true yarn run -s jest ./tests/e2e/suite.test.ts
+	
+.PHONY: test-ios-swift-prod
+test-ios-swift-prod:
+	@echo "\n>>>	🏃 Running prod iOS Swift client test suite...\n"
+	@# TODO: verify that xcodebuild and xcpretty are available
+	@cd tests/e2e/ios-swift && \
+		pod install
 	@make clear-mock && \
 		yarn run -s dev prod --config=./tests/e2e/ios-swift && \
 		cd tests/e2e/ios-swift && \


### PR DESCRIPTION
The iOS tests bottleneck our entire CI test suite, since they rely on us pulling down the Cocoapods spec cache. We can likely put our own cache up that has just analytics-ios.

For now, we can improve the iOS test suite time (and therefore, the entire test suite) by running dev and prod in parallel. This reduces iOS tests by about 2m, or ~15%.

We may need to adjust CI parallelism, TBD.

https://github.com/segmentio/typewriter/issues/99