### PR TITLE
[development] Rename prerelease script to release:pre

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "update": "make update",
     "lint": "eslint './src/**/*.{ts,tsx}'",
     "release": "yarn run build && np",
-    "prerelease": "yarn run build && np prerelease --any-branch --tag next --no-release-draft"
+    "release:pre": "yarn run build && np prerelease --any-branch --tag next --no-release-draft"
   },
   "engines": {
     "node": ">=0.10.15"


### PR DESCRIPTION
`prerelease` appears to be a `np` hook, which is causing `yarn release` to perform a pre-release