### PR TITLE
Release non-pre-releases on release branches instead of master

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "e2e": "make e2e",
     "update": "make update",
     "lint": "eslint './src/**/*.{ts,tsx}'",
-    "release": "yarn run build && np",
+    "release": "yarn run build && np --any-branch",
     "release:pre": "yarn run build && np prerelease --any-branch --tag next --no-release-draft"
   },
   "engines": {


### PR DESCRIPTION
Because of `master` branch protection, we can't do a release there. Instead:

- Check out the latest `master` with your merged PRs
- Check out a new branch `release/<new version number>`
- `yarn release`
- Fill out the release draft and publish it
- Push up branch as a PR and merge to `master`