### PR TITLE
Migrate v6 Android client to `androidx` from `android.support`

### DIFF
--- a/examples/gen-android/java/.gitignore
+++ b/examples/gen-android/java/.gitignore
@@ -9,7 +9,6 @@
 /build
 /captures
 .externalNativeBuild
-gradle.properties
 build/
 .classpath
 .project

--- a/examples/gen-android/java/app/src/main/java/com/segment/generated/KicksAppAnalytics.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/generated/KicksAppAnalytics.java
@@ -6,8 +6,8 @@ import com.segment.analytics.Analytics;
 import com.segment.analytics.Options;
 import com.segment.analytics.Properties;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class KicksAppAnalytics {
     private Analytics analytics;

--- a/examples/gen-android/java/app/src/main/java/com/segment/generated/OrderCompleted.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/generated/OrderCompleted.java
@@ -3,7 +3,7 @@ package com.segment.generated;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class OrderCompleted {
     private Properties properties;

--- a/examples/gen-android/java/app/src/main/java/com/segment/generated/Product.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/generated/Product.java
@@ -3,7 +3,7 @@ package com.segment.generated;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class Product {
     private Properties properties;

--- a/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/DisplayMessageActivity.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/DisplayMessageActivity.java
@@ -1,7 +1,7 @@
 package com.segment.typewriterexample;
 
 import android.content.Intent;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.widget.TextView;
 

--- a/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/MainActivity.java
+++ b/examples/gen-android/java/app/src/main/java/com/segment/typewriterexample/MainActivity.java
@@ -1,7 +1,7 @@
 package com.segment.typewriterexample;
 
 import android.content.Intent;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;

--- a/examples/gen-android/java/app/src/main/res/layout/activity_display_message.xml
+++ b/examples/gen-android/java/app/src/main/res/layout/activity_display_message.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -20,4 +20,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/gen-android/java/app/src/main/res/layout/activity_main.xml
+++ b/examples/gen-android/java/app/src/main/res/layout/activity_main.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -34,4 +34,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toEndOf="@+id/editText" />
-</android.support.constraint.ConstraintLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/gen-android/java/build.gradle
+++ b/examples/gen-android/java/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
-        
+        classpath 'com.android.tools.build:gradle:3.6.1'
+
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/gen-android/java/gradle.properties
+++ b/examples/gen-android/java/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/examples/gen-android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/gen-android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 27 20:27:56 PST 2019
+#Fri Mar 20 12:07:36 PDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/src/commands/gen-android.ts
+++ b/src/commands/gen-android.ts
@@ -215,7 +215,7 @@ class AnalyticsJavaWrapperRenderer extends JavaRenderer {
   protected emitClassDefinition(c: ClassType, className: Name): void {
     this.emitFileHeader(className, [
       'com.segment.analytics.Properties',
-      'android.support.annotation.NonNull'
+      'androidx.annotation.NonNull'
     ])
     // TODO: Emit class description, once we support top-level event descriptions in JSON Schema
     // this.emitDescription(this.descriptionForType(c));
@@ -296,8 +296,8 @@ class AnalyticsJavaWrapperRenderer extends JavaRenderer {
       'com.segment.analytics.Options',
       'com.segment.analytics.Properties',
       'android.content.Context',
-      'android.support.annotation.NonNull',
-      'android.support.annotation.Nullable'
+      'androidx.annotation.NonNull',
+      'androidx.annotation.Nullable'
     ])
     this.emitBlock(['public class ', className], () => {
       this.emitLine('private Analytics analytics;')

--- a/tests/commands/gen-android/__snapshots__/ExampleEvent.java
+++ b/tests/commands/gen-android/__snapshots__/ExampleEvent.java
@@ -3,7 +3,7 @@ package com.segment.analytics;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class ExampleEvent {
     private Properties properties;

--- a/tests/commands/gen-android/__snapshots__/OptionalArray.java
+++ b/tests/commands/gen-android/__snapshots__/OptionalArray.java
@@ -3,7 +3,7 @@ package com.segment.analytics;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class OptionalArray {
     private Properties properties;

--- a/tests/commands/gen-android/__snapshots__/OptionalObject.java
+++ b/tests/commands/gen-android/__snapshots__/OptionalObject.java
@@ -3,7 +3,7 @@ package com.segment.analytics;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class OptionalObject {
     private Properties properties;

--- a/tests/commands/gen-android/__snapshots__/RequiredArray.java
+++ b/tests/commands/gen-android/__snapshots__/RequiredArray.java
@@ -3,7 +3,7 @@ package com.segment.analytics;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class RequiredArray {
     private Properties properties;

--- a/tests/commands/gen-android/__snapshots__/RequiredObject.java
+++ b/tests/commands/gen-android/__snapshots__/RequiredObject.java
@@ -3,7 +3,7 @@ package com.segment.analytics;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class RequiredObject {
     private Properties properties;

--- a/tests/commands/gen-android/__snapshots__/TestTrackingPlanAnalytics.java
+++ b/tests/commands/gen-android/__snapshots__/TestTrackingPlanAnalytics.java
@@ -6,8 +6,8 @@ import com.segment.analytics.Analytics;
 import com.segment.analytics.Options;
 import com.segment.analytics.Properties;
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class TestTrackingPlanAnalytics {
     private Analytics analytics;

--- a/tests/commands/gen-android/__snapshots__/The42_TerribleEventName3.java
+++ b/tests/commands/gen-android/__snapshots__/The42_TerribleEventName3.java
@@ -3,7 +3,7 @@ package com.segment.analytics;
 
 import java.util.*;
 import com.segment.analytics.Properties;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public final class The42_TerribleEventName3 {
     private Properties properties;


### PR DESCRIPTION
This PR migrates the android generator on v6 to generate annotations using the `androidx` library instead of the unmaintained `android.support` package. This PR also updates the example app to use `androidx`.