### PR TITLE
Update iOS E2E Test to reflect null serialization support

### DIFF
--- a/src/generators/ios/ios.ts
+++ b/src/generators/ios/ios.ts
@@ -102,7 +102,7 @@ export const ios: Generator<{}, IOSTrackCallContext, IOSObjectContext, IOSProper
 		let object: IOSObjectContext | undefined = undefined
 
 		if (properties.length > 0) {
-			// If at least one property is set, generate a class that only allows the explicitely
+			// If at least one property is set, generate a class that only allows the explicitly
 			// allowed properties.
 			const className = client.namer.register(schema.name, 'class', {
 				transform: (name: string) => {
@@ -183,7 +183,7 @@ function defaultPropertyContext(
 				: 'strong, nonatomic, nullable'
 			: 'nonatomic',
 		isVariableNullable: !schema.isRequired || !!schema.isNullable,
-		isPayloadFieldNullable: !!schema.isNullable,
+		isPayloadFieldNullable: !!schema.isNullable && !!schema.isRequired,
 		isPointerType,
 	}
 }

--- a/tests/e2e/ios-objc/Podfile
+++ b/tests/e2e/ios-objc/Podfile
@@ -1,12 +1,12 @@
 use_frameworks!
 
 target 'TypewriterExample' do
-  pod "Analytics", "3.6.9"
+  pod "Analytics", "3.8.0-beta.1"
   platform :ios, "10.1"
 end
 
 target 'TypewriterExampleTests' do
-  pod "Analytics", "3.6.9"
+  pod "Analytics", "3.8.0-beta.1"
   platform :ios, "10.1"
 end
 

--- a/tests/e2e/ios-objc/Podfile.lock
+++ b/tests/e2e/ios-objc/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Analytics (3.6.9)
+  - Analytics (3.8.0-beta.1)
 
 DEPENDENCIES:
-  - Analytics (= 3.6.9)
+  - Analytics (= 3.8.0-beta.1)
 
 SPEC REPOS:
   trunk:
     - Analytics
 
 SPEC CHECKSUMS:
-  Analytics: 6541ce337e99d9f7a2240a8b3953940a7be5f998
+  Analytics: a40bd6f55193ca8d8757c23c71bb12605a6b2bcd
 
-PODFILE CHECKSUM: d136fa2c8688e2f211a1cc77c2b3505c2af384bf
+PODFILE CHECKSUM: 5ceaf0ce4e2714208ed9c381f9281b6b4920ed43
 
 COCOAPODS: 1.8.4

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalArrayWithPropertiesItem.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalArrayWithPropertiesItem.m
@@ -28,14 +28,30 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
-  properties[@"optional array"] = self.optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:self.optionalArray];
-  properties[@"optional boolean"] = self.optionalBoolean == nil ? [NSNull null] : self.optionalBoolean;
-  properties[@"optional int"] = self.optionalInt == nil ? [NSNull null] : self.optionalInt;
-  properties[@"optional number"] = self.optionalNumber == nil ? [NSNull null] : self.optionalNumber;
-  properties[@"optional object"] = self.optionalObject == nil ? [NSNull null] : self.optionalObject;
-  properties[@"optional string"] = self.optionalString == nil ? [NSNull null] : self.optionalString;
-  properties[@"optional string with regex"] = self.optionalStringWithRegex == nil ? [NSNull null] : self.optionalStringWithRegex;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
+  if (self.optionalArray != nil) {
+    properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
+  }
+  if (self.optionalBoolean != nil) {
+    properties[@"optional boolean"] = self.optionalBoolean;
+  }
+  if (self.optionalInt != nil) {
+    properties[@"optional int"] = self.optionalInt;
+  }
+  if (self.optionalNumber != nil) {
+    properties[@"optional number"] = self.optionalNumber;
+  }
+  if (self.optionalObject != nil) {
+    properties[@"optional object"] = self.optionalObject;
+  }
+  if (self.optionalString != nil) {
+    properties[@"optional string"] = self.optionalString;
+  }
+  if (self.optionalStringWithRegex != nil) {
+    properties[@"optional string with regex"] = self.optionalStringWithRegex;
+  }
 
   return properties;
 }

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalArrayWithPropertiesItem1.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalArrayWithPropertiesItem1.m
@@ -28,7 +28,9 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
   if (self.optionalArray != nil) {
     properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
   }

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalObjectWithProperties.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalObjectWithProperties.m
@@ -28,14 +28,30 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
-  properties[@"optional array"] = self.optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:self.optionalArray];
-  properties[@"optional boolean"] = self.optionalBoolean == nil ? [NSNull null] : self.optionalBoolean;
-  properties[@"optional int"] = self.optionalInt == nil ? [NSNull null] : self.optionalInt;
-  properties[@"optional number"] = self.optionalNumber == nil ? [NSNull null] : self.optionalNumber;
-  properties[@"optional object"] = self.optionalObject == nil ? [NSNull null] : self.optionalObject;
-  properties[@"optional string"] = self.optionalString == nil ? [NSNull null] : self.optionalString;
-  properties[@"optional string with regex"] = self.optionalStringWithRegex == nil ? [NSNull null] : self.optionalStringWithRegex;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
+  if (self.optionalArray != nil) {
+    properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
+  }
+  if (self.optionalBoolean != nil) {
+    properties[@"optional boolean"] = self.optionalBoolean;
+  }
+  if (self.optionalInt != nil) {
+    properties[@"optional int"] = self.optionalInt;
+  }
+  if (self.optionalNumber != nil) {
+    properties[@"optional number"] = self.optionalNumber;
+  }
+  if (self.optionalObject != nil) {
+    properties[@"optional object"] = self.optionalObject;
+  }
+  if (self.optionalString != nil) {
+    properties[@"optional string"] = self.optionalString;
+  }
+  if (self.optionalStringWithRegex != nil) {
+    properties[@"optional string with regex"] = self.optionalStringWithRegex;
+  }
 
   return properties;
 }

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalObjectWithProperties1.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGOptionalObjectWithProperties1.m
@@ -28,7 +28,9 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
   if (self.optionalArray != nil) {
     properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
   }

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterAnalytics.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterAnalytics.m
@@ -150,16 +150,36 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 options:(nullable SERIALIZABLE_DICT)options
 {
     NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-    properties[@"optional any"] = optionalAny == nil ? [NSNull null] : optionalAny;
-    properties[@"optional array"] = optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:optionalArray];
-    properties[@"optional array with properties"] = optionalArrayWithProperties == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:optionalArrayWithProperties];
-    properties[@"optional boolean"] = optionalBoolean == nil ? [NSNull null] : optionalBoolean;
-    properties[@"optional int"] = optionalInt == nil ? [NSNull null] : optionalInt;
-    properties[@"optional number"] = optionalNumber == nil ? [NSNull null] : optionalNumber;
-    properties[@"optional object"] = optionalObject == nil ? [NSNull null] : optionalObject;
-    properties[@"optional object with properties"] = optionalObjectWithProperties == nil ? [NSNull null] : [optionalObjectWithProperties toDictionary];
-    properties[@"optional string"] = optionalString == nil ? [NSNull null] : optionalString;
-    properties[@"optional string with regex"] = optionalStringWithRegex == nil ? [NSNull null] : optionalStringWithRegex;
+    if (optionalAny != nil) {
+      properties[@"optional any"] = optionalAny;
+    }
+    if (optionalArray != nil) {
+      properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:optionalArray];
+    }
+    if (optionalArrayWithProperties != nil) {
+      properties[@"optional array with properties"] = [SEGTypewriterUtils toSerializableArray:optionalArrayWithProperties];
+    }
+    if (optionalBoolean != nil) {
+      properties[@"optional boolean"] = optionalBoolean;
+    }
+    if (optionalInt != nil) {
+      properties[@"optional int"] = optionalInt;
+    }
+    if (optionalNumber != nil) {
+      properties[@"optional number"] = optionalNumber;
+    }
+    if (optionalObject != nil) {
+      properties[@"optional object"] = optionalObject;
+    }
+    if (optionalObjectWithProperties != nil) {
+      properties[@"optional object with properties"] = [optionalObjectWithProperties toDictionary];
+    }
+    if (optionalString != nil) {
+      properties[@"optional string"] = optionalString;
+    }
+    if (optionalStringWithRegex != nil) {
+      properties[@"optional string with regex"] = optionalStringWithRegex;
+    }
 
     [[SEGAnalytics sharedAnalytics] track:@"Every Nullable Optional Type" properties:properties options:[SEGTypewriterUtils withTypewriterContextFields:options]];
 }
@@ -232,7 +252,9 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 options:(nullable SERIALIZABLE_DICT)options
 {
     NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-    properties[@"optional any"] = optionalAny == nil ? [NSNull null] : optionalAny;
+    if (optionalAny != nil) {
+      properties[@"optional any"] = optionalAny;
+    }
     if (optionalArray != nil) {
       properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:optionalArray];
     }
@@ -342,8 +364,12 @@ largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
 options:(nullable SERIALIZABLE_DICT)options
 {
     NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-    properties[@"large nullable optional integer"] = largeNullableOptionalInteger == nil ? [NSNull null] : largeNullableOptionalInteger;
-    properties[@"large nullable optional number"] = largeNullableOptionalNumber == nil ? [NSNull null] : largeNullableOptionalNumber;
+    if (largeNullableOptionalInteger != nil) {
+      properties[@"large nullable optional integer"] = largeNullableOptionalInteger;
+    }
+    if (largeNullableOptionalNumber != nil) {
+      properties[@"large nullable optional number"] = largeNullableOptionalNumber;
+    }
     properties[@"large nullable required integer"] = largeNullableRequiredInteger == nil ? [NSNull null] : largeNullableRequiredInteger;
     properties[@"large nullable required number"] = largeNullableRequiredNumber == nil ? [NSNull null] : largeNullableRequiredNumber;
     if (largeOptionalInteger != nil) {

--- a/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
+++ b/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
@@ -156,35 +156,6 @@
                                         optionalObjectWithProperties:nil
                                                       optionalString:nil
                                              optionalStringWithRegex:nil];
-
-    SEGOptionalArrayWithPropertiesItem *nullableOptionalArrayWithNilProperties =
-        [SEGOptionalArrayWithPropertiesItem initWithOptionalAny:nil
-                                                  optionalArray:nil
-                                                optionalBoolean:nil
-                                                    optionalInt:nil
-                                                 optionalNumber:nil
-                                                 optionalObject:nil
-                                                 optionalString:nil
-                                        optionalStringWithRegex:nil];
-    SEGOptionalObjectWithProperties *nullableOptionalObjectWithNilProperties =
-        [SEGOptionalObjectWithProperties initWithOptionalAny:nil
-                                               optionalArray:nil
-                                             optionalBoolean:nil
-                                                 optionalInt:nil
-                                              optionalNumber:nil
-                                              optionalObject:nil
-                                              optionalString:nil
-                                     optionalStringWithRegex:nil];
-    [SEGTypewriterAnalytics everyNullableOptionalTypeWithOptionalAny:nil
-                                                       optionalArray:nil
-                                         optionalArrayWithProperties:@[nullableOptionalArrayWithNilProperties]
-                                                     optionalBoolean:nil
-                                                         optionalInt:nil
-                                                      optionalNumber:nil
-                                                      optionalObject:nil
-                                        optionalObjectWithProperties:nullableOptionalObjectWithNilProperties
-                                                      optionalString:nil
-                                             optionalStringWithRegex:nil];
     
     SEGOptionalArrayWithPropertiesItem *nullableOptionalArrayWithProperties =
         [SEGOptionalArrayWithPropertiesItem initWithOptionalAny:@"Rick Sanchez"

--- a/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
+++ b/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
@@ -87,10 +87,18 @@
                                 optionalObjectWithProperties:optionalObjectWithProperties
                                               optionalString:@"Alpha-Betrium"
                                      optionalStringWithRegex:@"Lawyer Morty"];
-    
-    // NOTE: It turns out analytics-ios does not support serializing null values: https://github.com/segmentio/analytics-ios/pull/706
-    // They are just removed from the object before submitting. Therefore, you cannot set a null + required field as null without
-    // it generating a violation in Protocols. If this becomes an issue, we can investigate a change to analytics-ios.
+
+    [SEGTypewriterAnalytics everyNullableRequiredTypeWithRequiredAny:nil
+                                                       requiredArray:nil
+                                         requiredArrayWithProperties:nil
+                                                     requiredBoolean:nil
+                                                         requiredInt:nil
+                                                      requiredNumber:nil
+                                                      requiredObject:nil
+                                        requiredObjectWithProperties:nil
+                                                      requiredString:nil
+                                             requiredStringWithRegex:nil];
+
     SEGRequiredArrayWithPropertiesItem *nullableRequiredArrayWithPropertiesItem =
         [SEGRequiredArrayWithPropertiesItem initWithRequiredAny:@"Rick Sanchez"
                                                   requiredArray:@[@137, @"C-137"]

--- a/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
+++ b/tests/e2e/ios-objc/TypewriterExampleTests/TypewriterExampleTests.m
@@ -88,14 +88,32 @@
                                               optionalString:@"Alpha-Betrium"
                                      optionalStringWithRegex:@"Lawyer Morty"];
 
+    SEGRequiredArrayWithPropertiesItem *nullableRequiredArrayWithNilPropertiesItem =
+        [SEGRequiredArrayWithPropertiesItem initWithRequiredAny:nil
+                                                  requiredArray:nil
+                                                requiredBoolean:nil
+                                                    requiredInt:nil
+                                                 requiredNumber:nil
+                                                 requiredObject:nil
+                                                 requiredString:nil
+                                        requiredStringWithRegex:nil];
+    SEGRequiredObjectWithProperties *nullableRequiredObjectWithNilProperties =
+        [SEGRequiredObjectWithProperties initWithRequiredAny:nil
+                                               requiredArray:nil
+                                             requiredBoolean:nil
+                                                 requiredInt:nil
+                                              requiredNumber:nil
+                                              requiredObject:nil
+                                              requiredString:nil
+                                     requiredStringWithRegex:nil];
     [SEGTypewriterAnalytics everyNullableRequiredTypeWithRequiredAny:nil
                                                        requiredArray:nil
-                                         requiredArrayWithProperties:nil
+                                         requiredArrayWithProperties:@[nullableRequiredArrayWithNilPropertiesItem]
                                                      requiredBoolean:nil
                                                          requiredInt:nil
                                                       requiredNumber:nil
                                                       requiredObject:nil
-                                        requiredObjectWithProperties:nil
+                                        requiredObjectWithProperties:nullableRequiredObjectWithNilProperties
                                                       requiredString:nil
                                              requiredStringWithRegex:nil];
 
@@ -136,6 +154,35 @@
                                                       optionalNumber:nil
                                                       optionalObject:nil
                                         optionalObjectWithProperties:nil
+                                                      optionalString:nil
+                                             optionalStringWithRegex:nil];
+
+    SEGOptionalArrayWithPropertiesItem *nullableOptionalArrayWithNilProperties =
+        [SEGOptionalArrayWithPropertiesItem initWithOptionalAny:nil
+                                                  optionalArray:nil
+                                                optionalBoolean:nil
+                                                    optionalInt:nil
+                                                 optionalNumber:nil
+                                                 optionalObject:nil
+                                                 optionalString:nil
+                                        optionalStringWithRegex:nil];
+    SEGOptionalObjectWithProperties *nullableOptionalObjectWithNilProperties =
+        [SEGOptionalObjectWithProperties initWithOptionalAny:nil
+                                               optionalArray:nil
+                                             optionalBoolean:nil
+                                                 optionalInt:nil
+                                              optionalNumber:nil
+                                              optionalObject:nil
+                                              optionalString:nil
+                                     optionalStringWithRegex:nil];
+    [SEGTypewriterAnalytics everyNullableOptionalTypeWithOptionalAny:nil
+                                                       optionalArray:nil
+                                         optionalArrayWithProperties:@[nullableOptionalArrayWithNilProperties]
+                                                     optionalBoolean:nil
+                                                         optionalInt:nil
+                                                      optionalNumber:nil
+                                                      optionalObject:nil
+                                        optionalObjectWithProperties:nullableOptionalObjectWithNilProperties
                                                       optionalString:nil
                                              optionalStringWithRegex:nil];
     

--- a/tests/e2e/ios-swift/Podfile
+++ b/tests/e2e/ios-swift/Podfile
@@ -1,7 +1,7 @@
 target 'TypewriterSwiftExample' do
   use_frameworks!
 
-  pod "Analytics", "3.6.9"
+  pod "Analytics", "3.8.0-beta.1"
   platform :ios, "12.2"
 
   target 'TypewriterSwiftExampleTests' do

--- a/tests/e2e/ios-swift/Podfile.lock
+++ b/tests/e2e/ios-swift/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - Analytics (3.6.9)
+  - Analytics (3.8.0-beta.1)
 
 DEPENDENCIES:
-  - Analytics (= 3.6.9)
+  - Analytics (= 3.8.0-beta.1)
 
 SPEC REPOS:
   trunk:
     - Analytics
 
 SPEC CHECKSUMS:
-  Analytics: 6541ce337e99d9f7a2240a8b3953940a7be5f998
+  Analytics: a40bd6f55193ca8d8757c23c71bb12605a6b2bcd
 
-PODFILE CHECKSUM: 6172ecd4679d8d862f20a1d3242a5d5fc6fa11d8
+PODFILE CHECKSUM: b4611ecae137b5c4d8858f402e1a07ef81cd09a3
 
 COCOAPODS: 1.8.4

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalArrayWithPropertiesItem.m
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalArrayWithPropertiesItem.m
@@ -28,14 +28,30 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
-  properties[@"optional array"] = self.optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:self.optionalArray];
-  properties[@"optional boolean"] = self.optionalBoolean == nil ? [NSNull null] : self.optionalBoolean;
-  properties[@"optional int"] = self.optionalInt == nil ? [NSNull null] : self.optionalInt;
-  properties[@"optional number"] = self.optionalNumber == nil ? [NSNull null] : self.optionalNumber;
-  properties[@"optional object"] = self.optionalObject == nil ? [NSNull null] : self.optionalObject;
-  properties[@"optional string"] = self.optionalString == nil ? [NSNull null] : self.optionalString;
-  properties[@"optional string with regex"] = self.optionalStringWithRegex == nil ? [NSNull null] : self.optionalStringWithRegex;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
+  if (self.optionalArray != nil) {
+    properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
+  }
+  if (self.optionalBoolean != nil) {
+    properties[@"optional boolean"] = self.optionalBoolean;
+  }
+  if (self.optionalInt != nil) {
+    properties[@"optional int"] = self.optionalInt;
+  }
+  if (self.optionalNumber != nil) {
+    properties[@"optional number"] = self.optionalNumber;
+  }
+  if (self.optionalObject != nil) {
+    properties[@"optional object"] = self.optionalObject;
+  }
+  if (self.optionalString != nil) {
+    properties[@"optional string"] = self.optionalString;
+  }
+  if (self.optionalStringWithRegex != nil) {
+    properties[@"optional string with regex"] = self.optionalStringWithRegex;
+  }
 
   return properties;
 }

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalArrayWithPropertiesItem1.m
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalArrayWithPropertiesItem1.m
@@ -28,7 +28,9 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
   if (self.optionalArray != nil) {
     properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
   }

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalObjectWithProperties.m
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalObjectWithProperties.m
@@ -28,14 +28,30 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
-  properties[@"optional array"] = self.optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:self.optionalArray];
-  properties[@"optional boolean"] = self.optionalBoolean == nil ? [NSNull null] : self.optionalBoolean;
-  properties[@"optional int"] = self.optionalInt == nil ? [NSNull null] : self.optionalInt;
-  properties[@"optional number"] = self.optionalNumber == nil ? [NSNull null] : self.optionalNumber;
-  properties[@"optional object"] = self.optionalObject == nil ? [NSNull null] : self.optionalObject;
-  properties[@"optional string"] = self.optionalString == nil ? [NSNull null] : self.optionalString;
-  properties[@"optional string with regex"] = self.optionalStringWithRegex == nil ? [NSNull null] : self.optionalStringWithRegex;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
+  if (self.optionalArray != nil) {
+    properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
+  }
+  if (self.optionalBoolean != nil) {
+    properties[@"optional boolean"] = self.optionalBoolean;
+  }
+  if (self.optionalInt != nil) {
+    properties[@"optional int"] = self.optionalInt;
+  }
+  if (self.optionalNumber != nil) {
+    properties[@"optional number"] = self.optionalNumber;
+  }
+  if (self.optionalObject != nil) {
+    properties[@"optional object"] = self.optionalObject;
+  }
+  if (self.optionalString != nil) {
+    properties[@"optional string"] = self.optionalString;
+  }
+  if (self.optionalStringWithRegex != nil) {
+    properties[@"optional string with regex"] = self.optionalStringWithRegex;
+  }
 
   return properties;
 }

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalObjectWithProperties1.m
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGOptionalObjectWithProperties1.m
@@ -28,7 +28,9 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex {
 
 -(nonnull SERIALIZABLE_DICT) toDictionary {
   NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-  properties[@"optional any"] = self.optionalAny == nil ? [NSNull null] : self.optionalAny;
+  if (self.optionalAny != nil) {
+    properties[@"optional any"] = self.optionalAny;
+  }
   if (self.optionalArray != nil) {
     properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:self.optionalArray];
   }

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGTypewriterAnalytics.m
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/SEGTypewriterAnalytics.m
@@ -150,16 +150,36 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 options:(nullable SERIALIZABLE_DICT)options
 {
     NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-    properties[@"optional any"] = optionalAny == nil ? [NSNull null] : optionalAny;
-    properties[@"optional array"] = optionalArray == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:optionalArray];
-    properties[@"optional array with properties"] = optionalArrayWithProperties == nil ? [NSNull null] : [SEGTypewriterUtils toSerializableArray:optionalArrayWithProperties];
-    properties[@"optional boolean"] = optionalBoolean == nil ? [NSNull null] : optionalBoolean;
-    properties[@"optional int"] = optionalInt == nil ? [NSNull null] : optionalInt;
-    properties[@"optional number"] = optionalNumber == nil ? [NSNull null] : optionalNumber;
-    properties[@"optional object"] = optionalObject == nil ? [NSNull null] : optionalObject;
-    properties[@"optional object with properties"] = optionalObjectWithProperties == nil ? [NSNull null] : [optionalObjectWithProperties toDictionary];
-    properties[@"optional string"] = optionalString == nil ? [NSNull null] : optionalString;
-    properties[@"optional string with regex"] = optionalStringWithRegex == nil ? [NSNull null] : optionalStringWithRegex;
+    if (optionalAny != nil) {
+      properties[@"optional any"] = optionalAny;
+    }
+    if (optionalArray != nil) {
+      properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:optionalArray];
+    }
+    if (optionalArrayWithProperties != nil) {
+      properties[@"optional array with properties"] = [SEGTypewriterUtils toSerializableArray:optionalArrayWithProperties];
+    }
+    if (optionalBoolean != nil) {
+      properties[@"optional boolean"] = optionalBoolean;
+    }
+    if (optionalInt != nil) {
+      properties[@"optional int"] = optionalInt;
+    }
+    if (optionalNumber != nil) {
+      properties[@"optional number"] = optionalNumber;
+    }
+    if (optionalObject != nil) {
+      properties[@"optional object"] = optionalObject;
+    }
+    if (optionalObjectWithProperties != nil) {
+      properties[@"optional object with properties"] = [optionalObjectWithProperties toDictionary];
+    }
+    if (optionalString != nil) {
+      properties[@"optional string"] = optionalString;
+    }
+    if (optionalStringWithRegex != nil) {
+      properties[@"optional string with regex"] = optionalStringWithRegex;
+    }
 
     [[SEGAnalytics sharedAnalytics] track:@"Every Nullable Optional Type" properties:properties options:[SEGTypewriterUtils withTypewriterContextFields:options]];
 }
@@ -232,7 +252,9 @@ optionalStringWithRegex:(nullable NSString *)optionalStringWithRegex
 options:(nullable SERIALIZABLE_DICT)options
 {
     NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-    properties[@"optional any"] = optionalAny == nil ? [NSNull null] : optionalAny;
+    if (optionalAny != nil) {
+      properties[@"optional any"] = optionalAny;
+    }
     if (optionalArray != nil) {
       properties[@"optional array"] = [SEGTypewriterUtils toSerializableArray:optionalArray];
     }
@@ -342,8 +364,12 @@ largeRequiredNumber:(nonnull NSNumber *)largeRequiredNumber
 options:(nullable SERIALIZABLE_DICT)options
 {
     NSMutableDictionary *properties = [[NSMutableDictionary alloc] init];
-    properties[@"large nullable optional integer"] = largeNullableOptionalInteger == nil ? [NSNull null] : largeNullableOptionalInteger;
-    properties[@"large nullable optional number"] = largeNullableOptionalNumber == nil ? [NSNull null] : largeNullableOptionalNumber;
+    if (largeNullableOptionalInteger != nil) {
+      properties[@"large nullable optional integer"] = largeNullableOptionalInteger;
+    }
+    if (largeNullableOptionalNumber != nil) {
+      properties[@"large nullable optional number"] = largeNullableOptionalNumber;
+    }
     properties[@"large nullable required integer"] = largeNullableRequiredInteger == nil ? [NSNull null] : largeNullableRequiredInteger;
     properties[@"large nullable required number"] = largeNullableRequiredNumber == nil ? [NSNull null] : largeNullableRequiredNumber;
     if (largeOptionalInteger != nil) {

--- a/tests/e2e/ios-swift/TypewriterSwiftExampleTests/TypewriterSwiftExampleTests.swift
+++ b/tests/e2e/ios-swift/TypewriterSwiftExampleTests/TypewriterSwiftExampleTests.swift
@@ -86,6 +86,36 @@ class TypewriterSwiftExampleTests: XCTestCase {
             optionalStringWithRegex:  "Lawyer Morty")
         
         SEGTypewriterAnalytics.everyNullableRequiredType(
+            withRequiredAny: nil,
+            requiredArray: nil,
+            requiredArrayWithProperties: [
+                SEGRequiredArrayWithPropertiesItem.initWithRequiredAny(
+                    nil,
+                    requiredArray: nil,
+                    requiredBoolean: nil,
+                    requiredInt: nil,
+                    requiredNumber: nil,
+                    requiredObject: nil,
+                    requiredString: nil,
+                    requiredStringWithRegex: nil),
+            ],
+            requiredBoolean: nil,
+            requiredInt: nil,
+            requiredNumber: nil,
+            requiredObject: nil,
+            requiredObjectWithProperties: SEGRequiredObjectWithProperties.initWithRequiredAny(
+                nil,
+                requiredArray: nil,
+                requiredBoolean: nil,
+                requiredInt: nil,
+                requiredNumber: nil,
+                requiredObject: nil,
+                requiredString: nil,
+                requiredStringWithRegex: nil),
+            requiredString: nil,
+            requiredStringWithRegex: nil)
+
+        SEGTypewriterAnalytics.everyNullableRequiredType(
             withRequiredAny: "Rick Sanchez",
             requiredArray: [137, "C-137"],
             requiredArrayWithProperties: [
@@ -207,7 +237,7 @@ class TypewriterSwiftExampleTests: XCTestCase {
             finishedFlushing = true
         }
         
-        SEGAnalytics.shared().flush()
+        SEGAnalytics.shared()!.flush()
         
         while(!finishedFlushing) {
             RunLoop.current.run(until: Date.init(timeIntervalSinceNow: 0.1))

--- a/tests/e2e/suite.test.ts
+++ b/tests/e2e/suite.test.ts
@@ -156,8 +156,6 @@ describe('e2e tests', () => {
 				// Passing null for all fields:
 				{
 					name: 'Every Nullable Required Type',
-					// analytics-ios does not serialize nulls, and instead drops those fields.
-					if: sdk !== SDK.IOS,
 					properties: {
 						'required any': null,
 						'required array': null,

--- a/tests/e2e/suite.test.ts
+++ b/tests/e2e/suite.test.ts
@@ -237,6 +237,11 @@ describe('e2e tests', () => {
 				// Passing null for all fields:
 				{
 					name: 'Every Nullable Optional Type',
+					// Unlike in JSON, there's no way to distinguish between a field not set, a field set to null,
+					// and a field set to a non-null value in Objective-C. For nullable optional fields, we choose
+					// to avoid serializing the field. For required fields, we serialize the value set to null.
+					// Therefore, we can't support this case on iOS.
+					if: sdk !== SDK.IOS,
 					properties: {
 						'optional any': null,
 						'optional array': null,

--- a/tests/e2e/suite.test.ts
+++ b/tests/e2e/suite.test.ts
@@ -237,8 +237,6 @@ describe('e2e tests', () => {
 				// Passing null for all fields:
 				{
 					name: 'Every Nullable Optional Type',
-					// analytics-ios does not serialize nulls, and instead drops those fields.
-					if: sdk !== SDK.IOS,
 					properties: {
 						'optional any': null,
 						'optional array': null,


### PR DESCRIPTION
`analytics-ios` recently released support for serializing `null` values in the request sent to the Segment Tracking API: https://github.com/segmentio/analytics-ios/issues/852

This was released as `v3.8.0-beta.1`. For folks using typewriter + `analytics-ios` of at least that version, null values for required fields will now be serialized. Optional fields set to `nil` continue to be removed before serialization.

Fixes https://github.com/segmentio/typewriter/issues/114