### PR TITLE
Upgrading lodash to latest version and use tilde range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typewriter",
-  "version": "7.4.0",
+  "version": "7.4.1",
   "description": "A compiler for generating strongly typed analytics clients via Segment Protocols",
   "repository": "ssh://git@github.com/segmentio/typewriter.git",
   "homepage": "https://github.com/segmentio/typewriter",
@@ -68,7 +68,7 @@
     "js-yaml": "^3.13.1",
     "json-stable-stringify": "^1.0.1",
     "latest-version": "^5.1.0",
-    "lodash": "4.17.20",
+    "lodash": "~4.17.20",
     "node-machine-id": "^1.1.12",
     "prettier": "^1.17.0",
     "react": "^16.9.0",

--- a/tests/e2e/android-java/app/src/main/java/com/segment/generated/TypewriterUtils.java
+++ b/tests/e2e/android-java/app/src/main/java/com/segment/generated/TypewriterUtils.java
@@ -14,7 +14,7 @@ public final class TypewriterUtils {
 
     static {
         typewriterCtx = new HashMap<>();
-        typewriterCtx.put("version", "7.4.0");
+        typewriterCtx.put("version", "7.4.1");
         typewriterCtx.put("language", "java");
     }
 

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterUtils.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterUtils.m
@@ -14,7 +14,7 @@
   NSDictionary<NSString *, id> *typewriterContext = @{
     @"typewriter": @{
       @"language": @"objective-c",
-      @"version": @"7.4.0"
+      @"version": @"7.4.1"
     }
   };
   NSMutableDictionary *context = [NSMutableDictionary dictionaryWithCapacity:customContext.count + typewriterContext.count];

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/TypewriterUtils.swift
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/TypewriterUtils.swift
@@ -29,7 +29,7 @@ class TypewriterUtils {
         let typewriterContext = [
             "typewriter": [
                 "language": "swift",
-                "version": "7.4.0"
+                "version": "7.4.1"
             ]
         ]
         

--- a/tests/e2e/node-javascript/analytics/index.js
+++ b/tests/e2e/node-javascript/analytics/index.js
@@ -114,7 +114,7 @@ function withTypewriterContext(message) {
 		context: __assign(__assign({}, message.context || {}), {
 			typewriter: {
 				language: 'javascript',
-				version: '7.4.0',
+				version: '7.4.1',
 			},
 		}),
 	})

--- a/tests/e2e/node-typescript/analytics/index.ts
+++ b/tests/e2e/node-typescript/analytics/index.ts
@@ -675,7 +675,7 @@ function withTypewriterContext<P, T extends Segment.TrackMessage<P>>(
 			...(message.context || {}),
 			typewriter: {
 				language: 'typescript',
-				version: '7.4.0',
+				version: '7.4.1',
 			},
 		},
 	}

--- a/tests/e2e/web-javascript/analytics/index.js
+++ b/tests/e2e/web-javascript/analytics/index.js
@@ -75,7 +75,7 @@ function withTypewriterContext(message = {}) {
 			...(message.context || {}),
 			typewriter: {
 				language: 'javascript',
-				version: '7.4.0',
+				version: '7.4.1',
 			},
 		},
 	}

--- a/tests/e2e/web-typescript/analytics/index.ts
+++ b/tests/e2e/web-typescript/analytics/index.ts
@@ -654,7 +654,7 @@ function withTypewriterContext(message: Segment.Options = {}): Segment.Options {
 			...(message.context || {}),
 			typewriter: {
 				language: 'typescript',
-				version: '7.4.0',
+				version: '7.4.1',
 			},
 		},
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4995,10 +4995,15 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-lodash@4.17.20, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.7.14:
+lodash@4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.5, lodash@^4.3.0, lodash@^4.7.14, lodash@~4.17.20:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This is upgrading lodash to the latest patch version to fix the following two vulnerabilities:
- https://app.snyk.io/vuln/SNYK-JS-LODASH-1040724
- https://app.snyk.io/vuln/SNYK-JS-LODASH-1018905

I also set the version using tilde range instead of pinning the exact version so we can have a better control on our side of when to upgrade transitive dependencies (at least for patches).

There is still a version 4.17.20 that is used as a dev dependency because of an older version of typewriter (7.3.0) which is included as a dev dependency. I am not sure exactly why this dependency on an older version of typewriter is required so I left it as is.
