### PR TITLE
make `userId` or `anonymousId` required for typescript type `TrackMessage`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typewriter",
-  "version": "7.4.1",
+  "version": "7.4.2",
   "description": "A compiler for generating strongly typed analytics clients via Segment Protocols",
   "repository": "ssh://git@github.com/segmentio/typewriter.git",
   "homepage": "https://github.com/segmentio/typewriter",

--- a/src/generators/javascript/templates/segment.hbs
+++ b/src/generators/javascript/templates/segment.hbs
@@ -19,15 +19,18 @@ export type Callback = () => void
 import AnalyticsNode from 'analytics-node'
 export { AnalyticsNode }
 
+ /**
+ * At least one of userId or anonymousId must be included in any identify call.
+ */
+type Identity =
+  { userId: string | number; anonymousId?: string | number; } |
+  { anonymousId: string | number; userId?: string | number;  };
+
 /**
  * TrackMessage represents a message payload for an analytics `.track()` call.
  * See: https://segment.com/docs/spec/track/
  */
-export interface TrackMessage<PropertiesType> extends Options, Record<string, any> {
-  /** The ID for this user in your database. */
-  userId?: string | number
-  /** An ID to associated with the user when you don’t know who they are. */
-  anonymousId?: string | number
+export type TrackMessage<PropertiesType> = Options & Record<string, any> & Identity & {
   /** A dictionary of properties for the event. */
   properties?: PropertiesType
   /**

--- a/tests/e2e/android-java/app/src/main/java/com/segment/generated/TypewriterUtils.java
+++ b/tests/e2e/android-java/app/src/main/java/com/segment/generated/TypewriterUtils.java
@@ -14,7 +14,7 @@ public final class TypewriterUtils {
 
     static {
         typewriterCtx = new HashMap<>();
-        typewriterCtx.put("version", "7.4.0");
+        typewriterCtx.put("version", "7.4.2");
         typewriterCtx.put("language", "java");
     }
 

--- a/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterUtils.m
+++ b/tests/e2e/ios-objc/TypewriterExample/Analytics/SEGTypewriterUtils.m
@@ -14,7 +14,7 @@
   NSDictionary<NSString *, id> *typewriterContext = @{
     @"typewriter": @{
       @"language": @"objective-c",
-      @"version": @"7.4.0"
+      @"version": @"7.4.2"
     }
   };
   NSMutableDictionary *context = [NSMutableDictionary dictionaryWithCapacity:customContext.count + typewriterContext.count];

--- a/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/TypewriterUtils.swift
+++ b/tests/e2e/ios-swift/TypewriterSwiftExample/Analytics/TypewriterUtils.swift
@@ -29,7 +29,7 @@ class TypewriterUtils {
         let typewriterContext = [
             "typewriter": [
                 "language": "swift",
-                "version": "7.4.0"
+                "version": "7.4.2"
             ]
         ]
         

--- a/tests/e2e/node-javascript/analytics/index.js
+++ b/tests/e2e/node-javascript/analytics/index.js
@@ -114,7 +114,7 @@ function withTypewriterContext(message) {
 		context: __assign(__assign({}, message.context || {}), {
 			typewriter: {
 				language: 'javascript',
-				version: '7.4.0',
+				version: '7.4.2',
 			},
 		}),
 	})

--- a/tests/e2e/node-typescript/analytics/index.ts
+++ b/tests/e2e/node-typescript/analytics/index.ts
@@ -675,7 +675,7 @@ function withTypewriterContext<P, T extends Segment.TrackMessage<P>>(
 			...(message.context || {}),
 			typewriter: {
 				language: 'typescript',
-				version: '7.4.0',
+				version: '7.4.2',
 			},
 		},
 	}

--- a/tests/e2e/node-typescript/analytics/segment.ts
+++ b/tests/e2e/node-typescript/analytics/segment.ts
@@ -5,26 +5,29 @@ import AnalyticsNode from 'analytics-node'
 export { AnalyticsNode }
 
 /**
+ * At least one of userId or anonymousId must be included in any identify call.
+ */
+type Identity =
+	| { userId: string | number; anonymousId?: string | number }
+	| { anonymousId: string | number; userId?: string | number }
+
+/**
  * TrackMessage represents a message payload for an analytics `.track()` call.
  * See: https://segment.com/docs/spec/track/
  */
-export interface TrackMessage<PropertiesType>
-	extends Options,
-		Record<string, any> {
-	/** The ID for this user in your database. */
-	userId?: string | number
-	/** An ID to associated with the user when you don’t know who they are. */
-	anonymousId?: string | number
-	/** A dictionary of properties for the event. */
-	properties?: PropertiesType
-	/**
-	 * A Javascript date object representing when the track took place.
-	 * If the track just happened, leave it out and we’ll use the server’s
-	 * time. If you’re importing data from the past make sure you to send
-	 * a timestamp.
-	 */
-	timestamp?: Date
-}
+export type TrackMessage<PropertiesType> = Options &
+	Record<string, any> &
+	Identity & {
+		/** A dictionary of properties for the event. */
+		properties?: PropertiesType
+		/**
+		 * A Javascript date object representing when the track took place.
+		 * If the track just happened, leave it out and we’ll use the server’s
+		 * time. If you’re importing data from the past make sure you to send
+		 * a timestamp.
+		 */
+		timestamp?: Date
+	}
 
 /** The callback exposed by analytics-node. */
 export type Callback = (err: Error) => void

--- a/tests/e2e/web-javascript/analytics/index.js
+++ b/tests/e2e/web-javascript/analytics/index.js
@@ -75,7 +75,7 @@ function withTypewriterContext(message = {}) {
 			...(message.context || {}),
 			typewriter: {
 				language: 'javascript',
-				version: '7.4.0',
+				version: '7.4.2',
 			},
 		},
 	}

--- a/tests/e2e/web-typescript/analytics/index.ts
+++ b/tests/e2e/web-typescript/analytics/index.ts
@@ -654,7 +654,7 @@ function withTypewriterContext(message: Segment.Options = {}): Segment.Options {
 			...(message.context || {}),
 			typewriter: {
 				language: 'typescript',
-				version: '7.4.0',
+				version: '7.4.2',
 			},
 		},
 	}


### PR DESCRIPTION
Proposed fix for https://github.com/segmentio/typewriter/issues/157 which was introduced by https://github.com/DefinitelyTyped/DefinitelyTyped/pull/43633 for `analytics-node`

Types being aligned to Segment docs:
![Screen Shot 2021-06-07 at 5 56 32 PM](https://user-images.githubusercontent.com/2846560/121092551-bab17000-c7b9-11eb-8737-906a65d07b0c.png)
