### PR TITLE
 Fix: roll back react to work with ink

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -16,8 +16,8 @@
     "@segment/snippet": "^4.4.0",
     "evergreen-ui": "^6.1.0",
     "next": "^10.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "request": "^2.88.0",
     "typescript": "^4.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "lodash": "4.17.21",
     "node-machine-id": "^1.1.12",
     "prettier": "^2.3.2",
-    "react": "^17.0.1",
+    "react": "^16.14.0",
     "semver": "^7.3.5",
     "sort-keys": "^5.0.0",
     "typescript": "^4..3.5",

--- a/tests/e2e/web-javascript/package.json
+++ b/tests/e2e/web-javascript/package.json
@@ -18,8 +18,8 @@
     "evergreen-ui": "^6.1.0",
     "express": "^4.17.1",
     "next": "^10.0.0",
-    "react": "^17.0.2",
-    "react-dom": "17.0.2",
+    "react": "^16.14.0",
+    "react-dom": "16.14.0",
     "request": "^2.88.0"
   },
   "devDependencies": {

--- a/tests/e2e/web-typescript/package.json
+++ b/tests/e2e/web-typescript/package.json
@@ -19,8 +19,8 @@
     "evergreen-ui": "^6.1.0",
     "express": "^4.17.1",
     "next": "^10.0.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^16.14.0",
+    "react-dom": "^16.14.0",
     "request": "^2.88.0",
     "typescript": "^4.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6382,7 +6382,7 @@ react-reconciler@^0.24.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react@^16.9.0:
+react@^16.14.0, react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
@@ -6390,14 +6390,6 @@ react@^16.9.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^17.0.1:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
the `ink`, `ink-link`, `ink-select-input`,  `ink-spinner`,  `and ink-text-input` deps don't work with `react`  17
