### PR TITLE
fix: add identity type to make ids conditional

### DIFF
--- a/src/cli/index.tsx
+++ b/src/cli/index.tsx
@@ -149,6 +149,7 @@ function toYargsHandler<P = unknown>(
 			anonymousId = await getAnonymousId()
 		} catch (error) {
 			typewriter.errorFired({
+				anonymousId: 'unknown',
 				error_string: 'Failed to generate an anonymous id',
 				error,
 			})

--- a/src/generators/javascript/templates/segment.hbs
+++ b/src/generators/javascript/templates/segment.hbs
@@ -20,14 +20,17 @@ import AnalyticsNode from 'analytics-node'
 export { AnalyticsNode }
 
 /**
+* At least one of userId or anonymousId must be included in any identify call.
+*/
+type Identity =
+{ userId: string | number; anonymousId?: string | number; } |
+{ anonymousId: string | number; userId?: string | number;  };
+
+/**
  * TrackMessage represents a message payload for an analytics `.track()` call.
  * See: https://segment.com/docs/spec/track/
  */
-export interface TrackMessage<PropertiesType> extends Options, Record<string, any> {
-  /** The ID for this user in your database. */
-  userId?: string | number
-  /** An ID to associated with the user when you don’t know who they are. */
-  anonymousId?: string | number
+export type TrackMessage<PropertiesType> = Options & Record<string, any> & Identity & {
   /** A dictionary of properties for the event. */
   properties?: PropertiesType
   /**


### PR DESCRIPTION
- makes either `userId` or `anonymousId` required rather than optional for both. 
- Adds a dummy `anonymousId` type to errorFired method since anonymousId is now a declared type. 

