### PR TITLE
fix(templates): add ajv import in analytucs-js.hbs template if isDevelopment is true

### DIFF
--- a/src/languages/templates/typescript/analytics-js.hbs
+++ b/src/languages/templates/typescript/analytics-js.hbs
@@ -1,3 +1,15 @@
+{{#if isDevelopment}}
+/**
+ * Ajv is a peer dependency for development builds. It's used to apply run-time validation
+ * to message payloads before passing them on to the underlying analytics instance.
+ *
+ * Note that the production bundle does not depend on Ajv.
+ * 
+ * You can install it with: `npm install --save-dev ajv` or `yarn add -D ajv`.
+ */
+import Ajv from 'ajv'
+{{/if}}
+
 /**
  * The analytics.js snippet should be available via window.analytics.
  * You can install it by following instructions at: https://segment.com/docs/sources/website/analytics.js/quickstart/


### PR DESCRIPTION
Includes ` import Ajv from 'ajv'` in the generated `segment.ts` file when `isDevelopment` is `true`. 
This needs to be done because `Ajv` is being used in `segment.ts` but is not being imported and that causes an error `Ajv is not defined`.

### Environment:

- Typewriter v8.0.6
- language JavaScript and TypeScript

Solves https://github.com/segmentio/typewriter/issues/265