### PR TITLE
fix: use boolean AND to support scripts on Windows

### DIFF
--- a/src/config/scripts.ts
+++ b/src/config/scripts.ts
@@ -16,7 +16,7 @@ export async function runScript(
   configPath: string,
   type: Scripts
 ): Promise<string> {
-  const scriptWithCD = `cd ${configPath}; ${script}`;
+  const scriptWithCD = `cd ${configPath} && ${script}`;
   const { stdout } = await exec(scriptWithCD, { timeout: EXEC_TIMEOUT }).catch(
     (err) => {
       const { stderr = "" } = err;


### PR DESCRIPTION
On Windows, the following command fails to execute properly due to a parsing issue in Command Prompt, the default command line executor for Node:

```ts
const scriptWithCD = `cd ${configPath}; ${script}`;
```

This prevents Windows users from running `typewriter` in configurations that rely on script execution.

This PR switches from the semicolon to a boolean AND (`&&`) which works the same way on Windows and *nix. It does technically change the behavior though: a semicolon on *nix will run both sides of the semicolon regardless of the exit code of the left-hand side. This change does require that the left-hand side execute and return a zero exit status, which is probably a safe thing to ensure regardless.

Fixes #233

Before:

```
> npx typewriter update

  × Error: Token script failed
   → Tried running: 'node -r dotenv/config -e
     "console.log(process.env.TYPEWRITER_TOKEN)"'
   → The system cannot find the path specified.

  If you are unable to resolve this issue, open an issue on GitHub
  (​https://github.com/segmentio/typewriter/issues/new​). Please include that you
  are using version 7.4.1 of Typewriter.
```

After:

```
> npx typewriter update

  ✔ Loaded Tracking Plan
    ↪  Downloading the latest version from Segment...

  ✔ Loaded Tracking Plan
    ↪  Downloading the latest version from Segment...
```