### PR TITLE
fix: reset to process.stdin/stdout when /dev/tty is not available

### DIFF
--- a/src/common/ttys.ts
+++ b/src/common/ttys.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import tty from 'tty';
-import assert from 'assert';
+import fs from "fs";
+import tty from "tty";
+import assert from "assert";
 
 // Based on https://github.com/TooTallNate/ttys/blob/master/index.js
 export const ttys: {
@@ -11,15 +11,23 @@ export const ttys: {
 if (tty.isatty(0)) {
   ttys.stdin = process.stdin;
 } else {
-  let ttyFd = fs.openSync('/dev/tty', 'r');
-  assert(tty.isatty(ttyFd));
-  ttys.stdin = new tty.ReadStream(ttyFd);
+  try {
+    let ttyFd = fs.openSync("/dev/tty", "r");
+    assert(tty.isatty(ttyFd));
+    ttys.stdin = new tty.ReadStream(ttyFd);
+  } catch {
+    ttys.stdin = process.stdin;
+  }
 }
 
 if (tty.isatty(1)) {
   ttys.stdout = process.stdout;
 } else {
-  let ttyFd = fs.openSync('/dev/tty', 'w');
-  assert(tty.isatty(ttyFd));
-  ttys.stdout = new tty.WriteStream(ttyFd);
+  try {
+    let ttyFd = fs.openSync("/dev/tty", "w");
+    assert(tty.isatty(ttyFd));
+    ttys.stdout = new tty.WriteStream(ttyFd);
+  } catch {
+    ttys.stdout = process.stdout;
+  }
 }


### PR DESCRIPTION
# Thanks for taking the time to contribute to Typewriter!

It is highly appreciated that you take the time to help improve Typewriter.
We appreciate it if you would take the time to document your Pull Request.

Sadly, if we don't receive enough information, or the Pull Request doesn't
align well with our roadmap, we might respectfully thank you for your time, and close the issue.

## Respect earns Respect 👏

Please respect our [Code of Conduct](CODE_OF_CONDUCT.md), in short:

* Using welcoming and inclusive language.
* Being respectful of differing viewpoints and experiences.
* Gracefully accepting constructive criticism.
* Focusing on what is best for the community.
* Showing empathy towards other community members.
