### PR TITLE
fix: validateAgainstSchema called on dev mode

### DIFF
--- a/src/__tests__/commands/__snapshots__/build.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/build.test.ts.snap
@@ -93,10 +93,8 @@ exports.setTypewriterOptions = setTypewriterOptions;
     * is invalid, the \`onViolation\` handler will be called.
     */
 function validateAgainstSchema(message, schema) {
-    var ajv = new ajv_1.default({ schemaId: 'auto', allErrors: true, verbose: true });
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-    if (!ajv.validate(schema, message) && ajv.errors) {
+    var ajv = new ajv_1.default({ allErrors: true, verbose: true });
+    if (!ajv.validate(schema, message.properties) && ajv.errors) {
         onViolation(message, ajv.errors);
     }
 }
@@ -107,7 +105,7 @@ function validateAgainstSchema(message, schema) {
 function withTypewriterContext(message) {
     return __assign(__assign({}, message), { context: __assign(__assign({}, (message.context || {})), { typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             } }) });
 }
 /**
@@ -119,9 +117,12 @@ function withTypewriterContext(message) {
  * 		call is fired.
  */
 function customViolationHandler(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Custom Violation Handler', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Custom Violation Handler\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.\\", \\"labels\\": {}, \\"properties\\": { \\"regex property\\": { \\"$id\\": \\"/properties/regex%20property\\", \\"description\\": \\"\\", \\"pattern\\": \\"Lawyer Morty|Evil Morty\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"regex property\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Custom Violation Handler', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -137,9 +138,12 @@ exports.customViolationHandler = customViolationHandler;
  * 		call is fired.
  */
 function defaultViolationHandler(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Default Violation Handler', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Default Violation Handler\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.\\", \\"labels\\": {}, \\"properties\\": { \\"regex property\\": { \\"$id\\": \\"/properties/regex%20property\\", \\"description\\": \\"\\", \\"pattern\\": \\"Lawyer Morty|Evil Morty\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"regex property\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Default Violation Handler', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -155,9 +159,12 @@ exports.defaultViolationHandler = defaultViolationHandler;
  * 		call is fired.
  */
 function enumTypes(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Enum Types', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Enum Types\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that client property sanitize enums.\\", \\"labels\\": {}, \\"properties\\": { \\"string const\\": { \\"$id\\": \\"/properties/string%20const\\", \\"description\\": \\"A string property that only accepts a single enum value.\\", \\"enum\\": [\\"Rick Sanchez\\"], \\"type\\": \\"string\\" }, \\"string enum\\": { \\"$id\\": \\"/properties/string%20enum\\", \\"description\\": \\"A string property that accepts multiple enum values.\\", \\"enum\\": [\\"Evil Morty\\", \\"Lawyer Morty\\"], \\"type\\": \\"string\\" } }, \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Enum Types', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -173,9 +180,12 @@ exports.enumTypes = enumTypes;
  * 		call is fired.
  */
 function everyNullableOptionalType(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Every Nullable Optional Type', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Every Nullable Optional Type\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.\\", \\"properties\\": { \\"optional any\\": { \\"$id\\": \\"/properties/optional%20any\\", \\"description\\": \\"Optional any property\\" }, \\"optional array\\": { \\"$id\\": \\"/properties/optional%20array\\", \\"description\\": \\"Optional array property\\", \\"type\\": [\\"array\\", \\"null\\"] }, \\"optional array with properties\\": { \\"$id\\": \\"/properties/optional%20array%20with%20properties\\", \\"description\\": \\"Optional array with properties\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items\\", \\"properties\\": { \\"optional any\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\", \\"description\\": \\"Optional any property\\" }, \\"optional array\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\", \\"description\\": \\"Optional array property\\", \\"type\\": [\\"array\\", \\"null\\"] }, \\"optional boolean\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\", \\"description\\": \\"Optional boolean property\\", \\"type\\": [\\"boolean\\", \\"null\\"] }, \\"optional int\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\", \\"description\\": \\"Optional integer property\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"optional number\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\", \\"description\\": \\"Optional number property\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"optional object\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\", \\"description\\": \\"Optional object property\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"optional string\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\", \\"description\\": \\"Optional string property\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"optional string with regex\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\", \\"description\\": \\"Optional string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": [\\"string\\", \\"null\\"] } }, \\"type\\": [\\"object\\", \\"null\\"] }, \\"type\\": [\\"array\\", \\"null\\"] }, \\"optional boolean\\": { \\"$id\\": \\"/properties/optional%20boolean\\", \\"description\\": \\"Optional boolean property\\", \\"type\\": [\\"boolean\\", \\"null\\"] }, \\"optional int\\": { \\"$id\\": \\"/properties/optional%20int\\", \\"description\\": \\"Optional integer property\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"optional number\\": { \\"$id\\": \\"/properties/optional%20number\\", \\"description\\": \\"Optional number property\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"optional object\\": { \\"$id\\": \\"/properties/optional%20object\\", \\"description\\": \\"Optional object property\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"optional object with properties\\": { \\"$id\\": \\"/properties/optional%20object%20with%20properties\\", \\"description\\": \\"Optional object with properties\\", \\"properties\\": { \\"optional any\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\", \\"description\\": \\"Optional any property\\" }, \\"optional array\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\", \\"description\\": \\"Optional array property\\", \\"type\\": [\\"array\\", \\"null\\"] }, \\"optional boolean\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\", \\"description\\": \\"Optional boolean property\\", \\"type\\": [\\"boolean\\", \\"null\\"] }, \\"optional int\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\", \\"description\\": \\"Optional integer property\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"optional number\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\", \\"description\\": \\"Optional number property\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"optional object\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\", \\"description\\": \\"Optional object property\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"optional string\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\", \\"description\\": \\"Optional string property\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"optional string with regex\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\", \\"description\\": \\"Optional string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": [\\"string\\", \\"null\\"] } }, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"optional string\\": { \\"$id\\": \\"/properties/optional%20string\\", \\"description\\": \\"Optional string property\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"optional string with regex\\": { \\"$id\\": \\"/properties/optional%20string%20with%20regex\\", \\"description\\": \\"Optional string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": [\\"string\\", \\"null\\"] } }, \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Every Nullable Optional Type', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -191,9 +201,12 @@ exports.everyNullableOptionalType = everyNullableOptionalType;
  * 		call is fired.
  */
 function everyNullableRequiredType(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Every Nullable Required Type', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Every Nullable Required Type\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.\\", \\"properties\\": { \\"required any\\": { \\"$id\\": \\"/properties/required%20any\\", \\"description\\": \\"Required any property\\" }, \\"required array\\": { \\"$id\\": \\"/properties/required%20array\\", \\"description\\": \\"Required array property\\", \\"type\\": [\\"array\\", \\"null\\"] }, \\"required array with properties\\": { \\"$id\\": \\"/properties/required%20array%20with%20properties\\", \\"description\\": \\"Required array with properties\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items\\", \\"properties\\": { \\"required any\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\", \\"description\\": \\"Required any property\\" }, \\"required array\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\", \\"description\\": \\"Required array property\\", \\"type\\": [\\"array\\", \\"null\\"] }, \\"required boolean\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\", \\"description\\": \\"Required boolean property\\", \\"type\\": [\\"boolean\\", \\"null\\"] }, \\"required int\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\", \\"description\\": \\"Required integer property\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"required number\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\", \\"description\\": \\"Required number property\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"required object\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\", \\"description\\": \\"Required object property\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"required string\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\", \\"description\\": \\"Required string property\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"required string with regex\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\", \\"description\\": \\"Required string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": [\\"string\\", \\"null\\"] } }, \\"required\\": [\\"required any\\", \\"required array\\", \\"required boolean\\", \\"required int\\", \\"required number\\", \\"required object\\", \\"required string\\", \\"required string with regex\\"], \\"type\\": [\\"object\\", \\"null\\"] }, \\"type\\": [\\"array\\", \\"null\\"] }, \\"required boolean\\": { \\"$id\\": \\"/properties/required%20boolean\\", \\"description\\": \\"Required boolean property\\", \\"type\\": [\\"boolean\\", \\"null\\"] }, \\"required int\\": { \\"$id\\": \\"/properties/required%20int\\", \\"description\\": \\"Required integer property\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"required number\\": { \\"$id\\": \\"/properties/required%20number\\", \\"description\\": \\"Required number property\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"required object\\": { \\"$id\\": \\"/properties/required%20object\\", \\"description\\": \\"Required object property\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"required object with properties\\": { \\"$id\\": \\"/properties/required%20object%20with%20properties\\", \\"description\\": \\"Required object with properties\\", \\"properties\\": { \\"required any\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\", \\"description\\": \\"Required any property\\" }, \\"required array\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\", \\"description\\": \\"Required array property\\", \\"type\\": [\\"array\\", \\"null\\"] }, \\"required boolean\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\", \\"description\\": \\"Required boolean property\\", \\"type\\": [\\"boolean\\", \\"null\\"] }, \\"required int\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\", \\"description\\": \\"Required integer property\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"required number\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\", \\"description\\": \\"Required number property\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"required object\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\", \\"description\\": \\"Required object property\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": [\\"object\\", \\"null\\"] }, \\"required string\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\", \\"description\\": \\"Required string property\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"required string with regex\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\", \\"description\\": \\"Required string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": [\\"string\\", \\"null\\"] } }, \\"required\\": [\\"required any\\", \\"required array\\", \\"required boolean\\", \\"required int\\", \\"required number\\", \\"required object\\", \\"required string\\", \\"required string with regex\\"], \\"type\\": [\\"object\\", \\"null\\"] }, \\"required string\\": { \\"$id\\": \\"/properties/required%20string\\", \\"description\\": \\"Required string property\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"required string with regex\\": { \\"$id\\": \\"/properties/required%20string%20with%20regex\\", \\"description\\": \\"Required string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": [\\"string\\", \\"null\\"] } }, \\"required\\": [\\"required any\\", \\"required array\\", \\"required boolean\\", \\"required int\\", \\"required number\\", \\"required object\\", \\"required string\\", \\"required string with regex\\", \\"required object with properties\\", \\"required array with properties\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Every Nullable Required Type', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -209,9 +222,12 @@ exports.everyNullableRequiredType = everyNullableRequiredType;
  * 		call is fired.
  */
 function everyOptionalType(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Every Optional Type', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Every Optional Type\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle all of the supported field types, as optional fields.\\", \\"properties\\": { \\"optional any\\": { \\"$id\\": \\"/properties/optional%20any\\", \\"description\\": \\"Optional any property\\" }, \\"optional array\\": { \\"$id\\": \\"/properties/optional%20array\\", \\"description\\": \\"Optional array property\\", \\"type\\": \\"array\\" }, \\"optional array with properties\\": { \\"$id\\": \\"/properties/optional%20array%20with%20properties\\", \\"description\\": \\"Optional array with properties\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items\\", \\"properties\\": { \\"optional any\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\", \\"description\\": \\"Optional any property\\" }, \\"optional array\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\", \\"description\\": \\"Optional array property\\", \\"type\\": \\"array\\" }, \\"optional boolean\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\", \\"description\\": \\"Optional boolean property\\", \\"type\\": \\"boolean\\" }, \\"optional int\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\", \\"description\\": \\"Optional integer property\\", \\"type\\": \\"integer\\" }, \\"optional number\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\", \\"description\\": \\"Optional number property\\", \\"type\\": \\"number\\" }, \\"optional object\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\", \\"description\\": \\"Optional object property\\", \\"key\\": \\"optional object\\", \\"properties\\": {}, \\"type\\": \\"object\\" }, \\"optional string\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\", \\"description\\": \\"Optional string property\\", \\"type\\": \\"string\\" }, \\"optional string with regex\\": { \\"$id\\": \\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\", \\"description\\": \\"Optional string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": \\"string\\" } }, \\"type\\": \\"object\\" }, \\"type\\": \\"array\\" }, \\"optional boolean\\": { \\"$id\\": \\"/properties/optional%20boolean\\", \\"description\\": \\"Optional boolean property\\", \\"type\\": \\"boolean\\" }, \\"optional int\\": { \\"$id\\": \\"/properties/optional%20int\\", \\"description\\": \\"Optional integer property\\", \\"type\\": \\"integer\\" }, \\"optional number\\": { \\"$id\\": \\"/properties/optional%20number\\", \\"description\\": \\"Optional number property\\", \\"type\\": \\"number\\" }, \\"optional object\\": { \\"$id\\": \\"/properties/optional%20object\\", \\"description\\": \\"Optional object property\\", \\"key\\": \\"optional object\\", \\"properties\\": {}, \\"type\\": \\"object\\" }, \\"optional object with properties\\": { \\"$id\\": \\"/properties/optional%20object%20with%20properties\\", \\"description\\": \\"Optional object with properties\\", \\"properties\\": { \\"optional any\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\", \\"description\\": \\"Optional any property\\" }, \\"optional array\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\", \\"description\\": \\"Optional array property\\", \\"type\\": \\"array\\" }, \\"optional boolean\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\", \\"description\\": \\"Optional boolean property\\", \\"type\\": \\"boolean\\" }, \\"optional int\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\", \\"description\\": \\"Optional integer property\\", \\"type\\": \\"integer\\" }, \\"optional number\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\", \\"description\\": \\"Optional number property\\", \\"type\\": \\"number\\" }, \\"optional object\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\", \\"description\\": \\"Optional object property\\", \\"key\\": \\"optional object\\", \\"properties\\": {}, \\"type\\": \\"object\\" }, \\"optional string\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\", \\"description\\": \\"Optional string property\\", \\"type\\": \\"string\\" }, \\"optional string with regex\\": { \\"$id\\": \\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\", \\"description\\": \\"Optional string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": \\"string\\" } }, \\"type\\": \\"object\\" }, \\"optional string\\": { \\"$id\\": \\"/properties/optional%20string\\", \\"description\\": \\"Optional string property\\", \\"type\\": \\"string\\" }, \\"optional string with regex\\": { \\"$id\\": \\"/properties/optional%20string%20with%20regex\\", \\"description\\": \\"Optional string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": \\"string\\" } }, \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Every Optional Type', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -227,9 +243,12 @@ exports.everyOptionalType = everyOptionalType;
  * 		call is fired.
  */
 function everyRequiredType(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Every Required Type', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Every Required Type\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle all of the supported field types, as required fields. \\", \\"properties\\": { \\"required any\\": { \\"$id\\": \\"/properties/required%20any\\", \\"description\\": \\"Required any property\\" }, \\"required array\\": { \\"$id\\": \\"/properties/required%20array\\", \\"description\\": \\"Required array property\\", \\"type\\": \\"array\\" }, \\"required array with properties\\": { \\"$id\\": \\"/properties/required%20array%20with%20properties\\", \\"description\\": \\"Required array with properties\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items\\", \\"properties\\": { \\"required any\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\", \\"description\\": \\"Required any property\\" }, \\"required array\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\", \\"description\\": \\"Required array property\\", \\"type\\": \\"array\\" }, \\"required boolean\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\", \\"description\\": \\"Required boolean property\\", \\"type\\": \\"boolean\\" }, \\"required int\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\", \\"description\\": \\"Required integer property\\", \\"type\\": \\"integer\\" }, \\"required number\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\", \\"description\\": \\"Required number property\\", \\"type\\": \\"number\\" }, \\"required object\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\", \\"description\\": \\"Required object property\\", \\"key\\": \\"required object\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": \\"object\\" }, \\"required string\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\", \\"description\\": \\"Required string property\\", \\"type\\": \\"string\\" }, \\"required string with regex\\": { \\"$id\\": \\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\", \\"description\\": \\"Required string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"required any\\", \\"required array\\", \\"required boolean\\", \\"required int\\", \\"required number\\", \\"required object\\", \\"required string\\", \\"required string with regex\\"], \\"type\\": \\"object\\" }, \\"type\\": \\"array\\" }, \\"required boolean\\": { \\"$id\\": \\"/properties/required%20boolean\\", \\"description\\": \\"Required boolean property\\", \\"type\\": \\"boolean\\" }, \\"required int\\": { \\"$id\\": \\"/properties/required%20int\\", \\"description\\": \\"Required integer property\\", \\"type\\": \\"integer\\" }, \\"required number\\": { \\"$id\\": \\"/properties/required%20number\\", \\"description\\": \\"Required number property\\", \\"type\\": \\"number\\" }, \\"required object\\": { \\"$id\\": \\"/properties/required%20object\\", \\"description\\": \\"Required object property\\", \\"key\\": \\"required object\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": \\"object\\" }, \\"required object with properties\\": { \\"$id\\": \\"/properties/required%20object%20with%20properties\\", \\"description\\": \\"Required object with properties\\", \\"properties\\": { \\"required any\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\", \\"description\\": \\"Required any property\\" }, \\"required array\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\", \\"description\\": \\"Required array property\\", \\"type\\": \\"array\\" }, \\"required boolean\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\", \\"description\\": \\"Required boolean property\\", \\"type\\": \\"boolean\\" }, \\"required int\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\", \\"description\\": \\"Required integer property\\", \\"type\\": \\"integer\\" }, \\"required number\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\", \\"description\\": \\"Required number property\\", \\"type\\": \\"number\\" }, \\"required object\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\", \\"description\\": \\"Required object property\\", \\"key\\": \\"required object\\", \\"properties\\": {}, \\"required\\": [], \\"type\\": \\"object\\" }, \\"required string\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\", \\"description\\": \\"Required string property\\", \\"type\\": \\"string\\" }, \\"required string with regex\\": { \\"$id\\": \\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\", \\"description\\": \\"Required string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"required any\\", \\"required array\\", \\"required boolean\\", \\"required int\\", \\"required number\\", \\"required object\\", \\"required string\\", \\"required string with regex\\"], \\"type\\": \\"object\\" }, \\"required string\\": { \\"$id\\": \\"/properties/required%20string\\", \\"description\\": \\"Required string property\\", \\"type\\": \\"string\\" }, \\"required string with regex\\": { \\"$id\\": \\"/properties/required%20string%20with%20regex\\", \\"description\\": \\"Required string property with a regex conditional\\", \\"pattern\\": \\"Evil Morty|Lawyer Morty\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"required any\\", \\"required array\\", \\"required boolean\\", \\"required int\\", \\"required number\\", \\"required object\\", \\"required string\\", \\"required string with regex\\", \\"required object with properties\\", \\"required array with properties\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Every Required Type', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -245,9 +264,12 @@ exports.everyRequiredType = everyRequiredType;
  * 		call is fired.
  */
 function largeNumbersEvent(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Large Numbers Event', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Large Numbers Event\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients correctly serialize large numbers (integers and floats).\\", \\"labels\\": {}, \\"properties\\": { \\"large nullable optional integer\\": { \\"$id\\": \\"/properties/large%20nullable%20optional%20integer\\", \\"description\\": \\"\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"large nullable optional number\\": { \\"$id\\": \\"/properties/large%20nullable%20optional%20number\\", \\"description\\": \\"\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"large nullable required integer\\": { \\"$id\\": \\"/properties/large%20nullable%20required%20integer\\", \\"description\\": \\"\\", \\"type\\": [\\"integer\\", \\"null\\"] }, \\"large nullable required number\\": { \\"$id\\": \\"/properties/large%20nullable%20required%20number\\", \\"description\\": \\"\\", \\"type\\": [\\"number\\", \\"null\\"] }, \\"large optional integer\\": { \\"$id\\": \\"/properties/large%20optional%20integer\\", \\"description\\": \\"\\", \\"type\\": \\"integer\\" }, \\"large optional number\\": { \\"$id\\": \\"/properties/large%20optional%20number\\", \\"description\\": \\"\\", \\"type\\": \\"number\\" }, \\"large required integer\\": { \\"$id\\": \\"/properties/large%20required%20integer\\", \\"description\\": \\"\\", \\"type\\": \\"integer\\" }, \\"large required number\\": { \\"$id\\": \\"/properties/large%20required%20number\\", \\"description\\": \\"\\", \\"type\\": \\"number\\" } }, \\"required\\": [\\"large required integer\\", \\"large required number\\", \\"large nullable required integer\\", \\"large nullable required number\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Large Numbers Event', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -263,9 +285,12 @@ exports.largeNumbersEvent = largeNumbersEvent;
  * 		call is fired.
  */
 function nestedArrays(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Nested Arrays', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Nested Arrays\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle arrays-within-arrays.\\", \\"labels\\": {}, \\"properties\\": { \\"universeCharacters\\": { \\"$id\\": \\"/properties/universeCharacters\\", \\"description\\": \\"All known characters from each universe.\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/universeCharacters/items\\", \\"description\\": \\"\\", \\"items\\": { \\"description\\": \\"\\", \\"id\\": \\"/properties/properties/properties/universeCharacters/items/items\\", \\"properties\\": { \\"name\\": { \\"description\\": \\"The character's name.\\", \\"id\\": \\"/properties/properties/properties/universeCharacters/items/items/properties/name\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"name\\"], \\"type\\": \\"object\\" }, \\"type\\": \\"array\\" }, \\"type\\": \\"array\\" } }, \\"required\\": [\\"universeCharacters\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Nested Arrays', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -281,9 +306,12 @@ exports.nestedArrays = nestedArrays;
  * 		call is fired.
  */
 function nestedObjects(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Nested Objects', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Nested Objects\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle objects-within-objects.\\", \\"labels\\": {}, \\"properties\\": { \\"garage\\": { \\"$id\\": \\"/properties/garage\\", \\"description\\": \\"\\", \\"properties\\": { \\"tunnel\\": { \\"$id\\": \\"/properties/properties/properties/garage/properties/tunnel\\", \\"description\\": \\"\\", \\"properties\\": { \\"subterranean lab\\": { \\"$id\\": \\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab\\", \\"description\\": \\"\\", \\"properties\\": { \\"jerry's memories\\": { \\"$id\\": \\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/jerry's%20memories\\", \\"description\\": \\"\\", \\"type\\": \\"array\\" }, \\"morty's memories\\": { \\"$id\\": \\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/morty's%20memories\\", \\"description\\": \\"\\", \\"type\\": \\"array\\" }, \\"summer's contingency plan\\": { \\"$id\\": \\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/summer's%20contingency%20plan\\", \\"description\\": \\"\\", \\"type\\": \\"string\\" } }, \\"required\\": [], \\"type\\": \\"object\\" } }, \\"required\\": [\\"subterranean lab\\"], \\"type\\": \\"object\\" } }, \\"required\\": [\\"tunnel\\"], \\"type\\": \\"object\\" } }, \\"required\\": [\\"garage\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Nested Objects', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -299,9 +327,12 @@ exports.nestedObjects = nestedObjects;
  * 		call is fired.
  */
 function propertiesCollided(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Properties Collided', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Properties Collided\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle collisions in property names within a single event.\\", \\"labels\\": {}, \\"properties\\": { \\"Property Collided\\": { \\"$id\\": \\"/properties/Property%20Collided\\", \\"description\\": \\"\\", \\"type\\": \\"string\\" }, \\"property_collided\\": { \\"$id\\": \\"/properties/property_collided\\", \\"description\\": \\"\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"property_collided\\", \\"Property Collided\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Properties Collided', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -317,9 +348,12 @@ exports.propertiesCollided = propertiesCollided;
  * 		call is fired.
  */
 function propertyObjectNameCollision1(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Property Object Name Collision #1', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Property Object Name Collision 1\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle collisions in object names across multiple events.\\", \\"labels\\": {}, \\"properties\\": { \\"universe\\": { \\"$id\\": \\"/properties/universe\\", \\"description\\": \\"\\", \\"properties\\": { \\"name\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/name\\", \\"description\\": \\"The common name of this universe.\\", \\"type\\": \\"string\\" }, \\"occupants\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/occupants\\", \\"description\\": \\"The most important occupants in this universe.\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/occupants/items\\", \\"description\\": \\"\\", \\"properties\\": { \\"name\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\", \\"description\\": \\"The name of this occupant.\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"name\\"], \\"type\\": \\"object\\" }, \\"type\\": \\"array\\" } }, \\"required\\": [\\"name\\", \\"occupants\\"], \\"type\\": \\"object\\" } }, \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Property Object Name Collision #1', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -335,9 +369,12 @@ exports.propertyObjectNameCollision1 = propertyObjectNameCollision1;
  * 		call is fired.
  */
 function propertyObjectNameCollision2(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Property Object Name Collision #2', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Property Object Name Collision 2\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients handle collisions in object names across multiple events.\\", \\"labels\\": {}, \\"properties\\": { \\"universe\\": { \\"$id\\": \\"/properties/universe\\", \\"description\\": \\"\\", \\"properties\\": { \\"name\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/name\\", \\"description\\": \\"The common name of this universe.\\", \\"type\\": \\"string\\" }, \\"occupants\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/occupants\\", \\"description\\": \\"The most important occupants in this universe.\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/occupants/items\\", \\"description\\": \\"\\", \\"properties\\": { \\"name\\": { \\"$id\\": \\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\", \\"description\\": \\"The name of this occupant.\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"name\\"], \\"type\\": \\"object\\" }, \\"type\\": \\"array\\" } }, \\"required\\": [\\"name\\", \\"occupants\\"], \\"type\\": \\"object\\" } }, \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Property Object Name Collision #2', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -353,9 +390,12 @@ exports.propertyObjectNameCollision2 = propertyObjectNameCollision2;
  * 		call is fired.
  */
 function propertySanitized(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Property Sanitized', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Property Sanitized\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients sanitize property names that contain invalid identifier characters.\\", \\"labels\\": {}, \\"properties\\": { \\"0000---terrible-property-name~!3\\": { \\"$id\\": \\"/properties/0000---terrible-property-name~!3\\", \\"description\\": \\"\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"0000---terrible-property-name~!3\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Property Sanitized', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -371,9 +411,12 @@ exports.propertySanitized = propertySanitized;
  * 		call is fired.
  */
 function simpleArrayTypes(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Simple Array Types', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Simple Array Types\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients support fields with various types of arrays.\\", \\"labels\\": {}, \\"properties\\": { \\"any\\": { \\"$id\\": \\"/properties/any\\", \\"description\\": \\"\\", \\"items\\": { \\"description\\": \\"\\" }, \\"type\\": \\"array\\" }, \\"boolean\\": { \\"$id\\": \\"/properties/boolean\\", \\"description\\": \\"\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/boolean/items\\", \\"description\\": \\"\\", \\"type\\": \\"boolean\\" }, \\"type\\": \\"array\\" }, \\"integer\\": { \\"$id\\": \\"/properties/integer\\", \\"description\\": \\"\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/integer/items\\", \\"description\\": \\"\\", \\"type\\": \\"integer\\" }, \\"type\\": \\"array\\" }, \\"nullable\\": { \\"$id\\": \\"/properties/nullable\\", \\"description\\": \\"\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/nullable/items\\", \\"description\\": \\"\\", \\"type\\": [\\"string\\", \\"null\\"] }, \\"type\\": \\"array\\" }, \\"number\\": { \\"$id\\": \\"/properties/number\\", \\"description\\": \\"\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/number/items\\", \\"description\\": \\"\\", \\"type\\": \\"number\\" }, \\"type\\": \\"array\\" }, \\"object\\": { \\"$id\\": \\"/properties/object\\", \\"description\\": \\"\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/object/items\\", \\"description\\": \\"\\", \\"properties\\": { \\"name\\": { \\"$id\\": \\"/properties/properties/properties/object/items/properties/name\\", \\"description\\": \\"\\", \\"type\\": \\"string\\" } }, \\"required\\": [], \\"type\\": \\"object\\" }, \\"type\\": \\"array\\" }, \\"string\\": { \\"$id\\": \\"/properties/string\\", \\"description\\": \\"\\", \\"items\\": { \\"$id\\": \\"/properties/properties/properties/string/items\\", \\"description\\": \\"\\", \\"type\\": \\"string\\" }, \\"type\\": \\"array\\" } }, \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Simple Array Types', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -389,9 +432,12 @@ exports.simpleArrayTypes = simpleArrayTypes;
  * 		call is fired.
  */
 function unionType(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'Union Type', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"Union Type\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Validates that clients support fields with multiple (union) types.\\", \\"labels\\": {}, \\"properties\\": { \\"universe_name\\": { \\"$id\\": \\"/properties/universe_name\\", \\"description\\": \\"\\", \\"type\\": [\\"string\\", \\"null\\", \\"integer\\"] } }, \\"required\\": [\\"universe_name\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'Union Type', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -407,9 +453,12 @@ exports.unionType = unionType;
  * 		call is fired.
  */
 function noIDType(message, callback) {
+    var event = withTypewriterContext(__assign(__assign({}, message), { event: 'NoID type', properties: __assign({}, message.properties) }));
+    var schema = { \\"$id\\": \\"NoID Type\\", \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\", \\"description\\": \\"Properties without IDs\\", \\"labels\\": {}, \\"properties\\": { \\"no_id_prop\\": { \\"description\\": \\"a property without an ID\\", \\"type\\": \\"string\\" } }, \\"required\\": [\\"no_id_prop\\"], \\"type\\": \\"object\\" };
+    validateAgainstSchema(event, schema);
     var a = analytics();
     if (a) {
-        a.track(withTypewriterContext(__assign(__assign({}, message), { event: 'NoID type', properties: __assign({}, message.properties) })), callback);
+        a.track(event, callback);
     }
     else {
         throw missingAnalyticsNodeError;
@@ -5118,7 +5167,7 @@ export interface NoIDType {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv from 'ajv'
+import Ajv, { ErrorObject } from 'ajv'
 
 /**
  * The analytics.js snippet should be available via window.analytics.
@@ -5223,7 +5272,7 @@ export interface Context extends Record<string, any> {
 
 export type ViolationHandler = (
     message: Record<string, any>,
-    violations: Ajv.ErrorObject[]
+    violations: ErrorObject[]
 ) => void
 
 /**
@@ -5296,9 +5345,7 @@ function validateAgainstSchema(
     message: Record<string, any>,
     schema: object
 ) {
-    const ajv = new Ajv({ schemaId: 'auto', allErrors: true, verbose: true })
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+    const ajv = new Ajv({ allErrors: true, verbose: true })
 
     if (!ajv.validate(schema, message) && ajv.errors) {
         onViolation(message, ajv.errors)
@@ -5316,7 +5363,7 @@ function withTypewriterContext(message: Options = {}): Options {
             ...(message.context || {}),
             typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             },
         },
     };
@@ -5331,6 +5378,10 @@ function withTypewriterContext(message: Options = {}): Options {
  * 	call is fired.
  */
 export function customViolationHandler(props: CustomViolationHandler, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Custom Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Custom Violation Handler', props || {}, {...options,   context: {
@@ -5351,6 +5402,10 @@ export function customViolationHandler(props: CustomViolationHandler, options?: 
  * 	call is fired.
  */
 export function defaultViolationHandler(props: DefaultViolationHandler, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Default Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Default Violation Handler', props || {}, {...options,   context: {
@@ -5371,6 +5426,10 @@ export function defaultViolationHandler(props: DefaultViolationHandler, options?
  * 	call is fired.
  */
 export function enumTypes(props: EnumTypes, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Enum Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that client property sanitize enums.\\",\\"labels\\":{},\\"properties\\":{\\"string const\\":{\\"$id\\":\\"/properties/string%20const\\",\\"description\\":\\"A string property that only accepts a single enum value.\\",\\"enum\\":[\\"Rick Sanchez\\"],\\"type\\":\\"string\\"},\\"string enum\\":{\\"$id\\":\\"/properties/string%20enum\\",\\"description\\":\\"A string property that accepts multiple enum values.\\",\\"enum\\":[\\"Evil Morty\\",\\"Lawyer Morty\\"],\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Enum Types', props || {}, {...options,   context: {
@@ -5391,6 +5450,10 @@ export function enumTypes(props: EnumTypes, options?: Options, callback?: Callba
  * 	call is fired.
  */
 export function everyNullableOptionalType(props: EveryNullableOptionalType, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Every Nullable Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Every Nullable Optional Type', props || {}, {...options,   context: {
@@ -5411,6 +5474,10 @@ export function everyNullableOptionalType(props: EveryNullableOptionalType, opti
  * 	call is fired.
  */
 export function everyNullableRequiredType(props: EveryNullableRequiredType, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Every Nullable Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Every Nullable Required Type', props || {}, {...options,   context: {
@@ -5431,6 +5498,10 @@ export function everyNullableRequiredType(props: EveryNullableRequiredType, opti
  * 	call is fired.
  */
 export function everyOptionalType(props: EveryOptionalType, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Every Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as optional fields.\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Every Optional Type', props || {}, {...options,   context: {
@@ -5451,6 +5522,10 @@ export function everyOptionalType(props: EveryOptionalType, options?: Options, c
  * 	call is fired.
  */
 export function everyRequiredType(props: EveryRequiredType, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Every Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as required fields. \\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Every Required Type', props || {}, {...options,   context: {
@@ -5471,6 +5546,10 @@ export function everyRequiredType(props: EveryRequiredType, options?: Options, c
  * 	call is fired.
  */
 export function largeNumbersEvent(props: LargeNumbersEvent, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Large Numbers Event\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients correctly serialize large numbers (integers and floats).\\",\\"labels\\":{},\\"properties\\":{\\"large nullable optional integer\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable optional number\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large nullable required integer\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable required number\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large optional integer\\":{\\"$id\\":\\"/properties/large%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large optional number\\":{\\"$id\\":\\"/properties/large%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"large required integer\\":{\\"$id\\":\\"/properties/large%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large required number\\":{\\"$id\\":\\"/properties/large%20required%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"}},\\"required\\":[\\"large required integer\\",\\"large required number\\",\\"large nullable required integer\\",\\"large nullable required number\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Large Numbers Event', props || {}, {...options,   context: {
@@ -5491,6 +5570,10 @@ export function largeNumbersEvent(props: LargeNumbersEvent, options?: Options, c
  * 	call is fired.
  */
 export function nestedArrays(props: NestedArrays, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Nested Arrays\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle arrays-within-arrays.\\",\\"labels\\":{},\\"properties\\":{\\"universeCharacters\\":{\\"$id\\":\\"/properties/universeCharacters\\",\\"description\\":\\"All known characters from each universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universeCharacters/items\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items\\",\\"properties\\":{\\"name\\":{\\"description\\":\\"The character's name.\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items/properties/name\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"universeCharacters\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Nested Arrays', props || {}, {...options,   context: {
@@ -5511,6 +5594,10 @@ export function nestedArrays(props: NestedArrays, options?: Options, callback?: 
  * 	call is fired.
  */
 export function nestedObjects(props: NestedObjects, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Nested Objects\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle objects-within-objects.\\",\\"labels\\":{},\\"properties\\":{\\"garage\\":{\\"$id\\":\\"/properties/garage\\",\\"description\\":\\"\\",\\"properties\\":{\\"tunnel\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel\\",\\"description\\":\\"\\",\\"properties\\":{\\"subterranean lab\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab\\",\\"description\\":\\"\\",\\"properties\\":{\\"jerry's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/jerry's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"morty's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/morty's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"summer's contingency plan\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/summer's%20contingency%20plan\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"}},\\"required\\":[\\"subterranean lab\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"tunnel\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"garage\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Nested Objects', props || {}, {...options,   context: {
@@ -5531,6 +5618,10 @@ export function nestedObjects(props: NestedObjects, options?: Options, callback?
  * 	call is fired.
  */
 export function propertiesCollided(props: PropertiesCollided, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Properties Collided\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle collisions in property names within a single event.\\",\\"labels\\":{},\\"properties\\":{\\"Property Collided\\":{\\"$id\\":\\"/properties/Property%20Collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"property_collided\\":{\\"$id\\":\\"/properties/property_collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"property_collided\\",\\"Property Collided\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Properties Collided', props || {}, {...options,   context: {
@@ -5551,6 +5642,10 @@ export function propertiesCollided(props: PropertiesCollided, options?: Options,
  * 	call is fired.
  */
 export function propertyObjectNameCollision1(props: PropertyObjectNameCollision1, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Property Object Name Collision 1\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle collisions in object names across multiple events.\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Property Object Name Collision #1', props || {}, {...options,   context: {
@@ -5571,6 +5666,10 @@ export function propertyObjectNameCollision1(props: PropertyObjectNameCollision1
  * 	call is fired.
  */
 export function propertyObjectNameCollision2(props: PropertyObjectNameCollision2, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Property Object Name Collision 2\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle collisions in object names across multiple events.\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Property Object Name Collision #2', props || {}, {...options,   context: {
@@ -5591,6 +5690,10 @@ export function propertyObjectNameCollision2(props: PropertyObjectNameCollision2
  * 	call is fired.
  */
 export function propertySanitized(props: PropertySanitized, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Property Sanitized\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients sanitize property names that contain invalid identifier characters.\\",\\"labels\\":{},\\"properties\\":{\\"0000---terrible-property-name~!3\\":{\\"$id\\":\\"/properties/0000---terrible-property-name~!3\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"0000---terrible-property-name~!3\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Property Sanitized', props || {}, {...options,   context: {
@@ -5611,6 +5714,10 @@ export function propertySanitized(props: PropertySanitized, options?: Options, c
  * 	call is fired.
  */
 export function simpleArrayTypes(props: SimpleArrayTypes, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Simple Array Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients support fields with various types of arrays.\\",\\"labels\\":{},\\"properties\\":{\\"any\\":{\\"$id\\":\\"/properties/any\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\"},\\"type\\":\\"array\\"},\\"boolean\\":{\\"$id\\":\\"/properties/boolean\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/boolean/items\\",\\"description\\":\\"\\",\\"type\\":\\"boolean\\"},\\"type\\":\\"array\\"},\\"integer\\":{\\"$id\\":\\"/properties/integer\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/integer/items\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"type\\":\\"array\\"},\\"nullable\\":{\\"$id\\":\\"/properties/nullable\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/nullable/items\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"type\\":\\"array\\"},\\"number\\":{\\"$id\\":\\"/properties/number\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/number/items\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"type\\":\\"array\\"},\\"object\\":{\\"$id\\":\\"/properties/object\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/object/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/object/items/properties/name\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"string\\":{\\"$id\\":\\"/properties/string\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/string/items\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"type\\":\\"array\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Simple Array Types', props || {}, {...options,   context: {
@@ -5631,6 +5738,10 @@ export function simpleArrayTypes(props: SimpleArrayTypes, options?: Options, cal
  * 	call is fired.
  */
 export function unionType(props: UnionType, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"Union Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients support fields with multiple (union) types.\\",\\"labels\\":{},\\"properties\\":{\\"universe_name\\":{\\"$id\\":\\"/properties/universe_name\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\",\\"integer\\"]}},\\"required\\":[\\"universe_name\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('Union Type', props || {}, {...options,   context: {
@@ -5651,6 +5762,10 @@ export function unionType(props: UnionType, options?: Options, callback?: Callba
  * 	call is fired.
  */
 export function noIDType(props: NoIDType, options?: Options, callback?: Callback): void {
+
+    const schema = {\\"$id\\":\\"NoID Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Properties without IDs\\",\\"labels\\":{},\\"properties\\":{\\"no_id_prop\\":{\\"description\\":\\"a property without an ID\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"no_id_prop\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(props, schema);
+
     const a = analytics();
     if (a) {
         a.track('NoID type', props || {}, {...options,   context: {
@@ -6542,7 +6657,7 @@ export interface NoIDType {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv from 'ajv'
+import Ajv, { ErrorObject } from 'ajv'
 import AnalyticsNode from 'analytics-node'
 
 /**
@@ -6658,7 +6773,7 @@ export interface Context extends Record<string, any> {
 
 export type ViolationHandler = (
     message: TrackMessage<Record<string, any>>,
-    violations: Ajv.ErrorObject[]
+    violations: ErrorObject[]
 ) => void
 
 /**
@@ -6752,11 +6867,9 @@ function validateAgainstSchema(
     message: TrackMessage<Record<string, any>>,
     schema: object
 ) {
-    const ajv = new Ajv({ schemaId: 'auto', allErrors: true, verbose: true })
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+    const ajv = new Ajv({ allErrors: true, verbose: true })
 
-    if (!ajv.validate(schema, message) && ajv.errors) {
+    if (!ajv.validate(schema, message.properties) && ajv.errors) {
         onViolation(message, ajv.errors)
     }
 }
@@ -6774,7 +6887,7 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
             ...(message.context || {}),
             typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             },
         },
     }
@@ -6793,18 +6906,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<CustomViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Custom Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Custom Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"This event is fired in order to trigger a custom violation handler. It should be called with a JSON Schema violation.\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Custom Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6821,18 +6935,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<DefaultViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Default Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Default Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"This event is fired in order to trigger the default violation handler. It should be called with a JSON Schema violation.\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Default Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6849,18 +6964,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EnumTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Enum Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Enum Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that client property sanitize enums.\\",\\"labels\\":{},\\"properties\\":{\\"string const\\":{\\"$id\\":\\"/properties/string%20const\\",\\"description\\":\\"A string property that only accepts a single enum value.\\",\\"enum\\":[\\"Rick Sanchez\\"],\\"type\\":\\"string\\"},\\"string enum\\":{\\"$id\\":\\"/properties/string%20enum\\",\\"description\\":\\"A string property that accepts multiple enum values.\\",\\"enum\\":[\\"Evil Morty\\",\\"Lawyer Morty\\"],\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Enum Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6877,18 +6993,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Nullable Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as nullable optional fields. If a field is null, it is expected to be NOT sent through.\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6905,18 +7022,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Nullable Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as nullable required fields. If a field is null, it is expected to be sent through.\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6933,18 +7051,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as optional fields.\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6961,18 +7080,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle all of the supported field types, as required fields. \\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -6989,18 +7109,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<LargeNumbersEvent>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Large Numbers Event',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Large Numbers Event\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients correctly serialize large numbers (integers and floats).\\",\\"labels\\":{},\\"properties\\":{\\"large nullable optional integer\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable optional number\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large nullable required integer\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable required number\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large optional integer\\":{\\"$id\\":\\"/properties/large%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large optional number\\":{\\"$id\\":\\"/properties/large%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"large required integer\\":{\\"$id\\":\\"/properties/large%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large required number\\":{\\"$id\\":\\"/properties/large%20required%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"}},\\"required\\":[\\"large required integer\\",\\"large required number\\",\\"large nullable required integer\\",\\"large nullable required number\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Large Numbers Event',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7017,18 +7138,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedArrays>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Arrays',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Nested Arrays\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle arrays-within-arrays.\\",\\"labels\\":{},\\"properties\\":{\\"universeCharacters\\":{\\"$id\\":\\"/properties/universeCharacters\\",\\"description\\":\\"All known characters from each universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universeCharacters/items\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items\\",\\"properties\\":{\\"name\\":{\\"description\\":\\"The character's name.\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items/properties/name\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"universeCharacters\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Arrays',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7045,18 +7167,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedObjects>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Objects',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Nested Objects\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle objects-within-objects.\\",\\"labels\\":{},\\"properties\\":{\\"garage\\":{\\"$id\\":\\"/properties/garage\\",\\"description\\":\\"\\",\\"properties\\":{\\"tunnel\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel\\",\\"description\\":\\"\\",\\"properties\\":{\\"subterranean lab\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab\\",\\"description\\":\\"\\",\\"properties\\":{\\"jerry's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/jerry's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"morty's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/morty's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"summer's contingency plan\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/summer's%20contingency%20plan\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"}},\\"required\\":[\\"subterranean lab\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"tunnel\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"garage\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Objects',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7073,18 +7196,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertiesCollided>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Properties Collided',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Properties Collided\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle collisions in property names within a single event.\\",\\"labels\\":{},\\"properties\\":{\\"Property Collided\\":{\\"$id\\":\\"/properties/Property%20Collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"property_collided\\":{\\"$id\\":\\"/properties/property_collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"property_collided\\",\\"Property Collided\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Properties Collided',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7101,18 +7225,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision1>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #1',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Object Name Collision 1\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle collisions in object names across multiple events.\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #1',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7129,18 +7254,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision2>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #2',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Object Name Collision 2\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients handle collisions in object names across multiple events.\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #2',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7157,18 +7283,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertySanitized>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Sanitized',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Sanitized\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients sanitize property names that contain invalid identifier characters.\\",\\"labels\\":{},\\"properties\\":{\\"0000---terrible-property-name~!3\\":{\\"$id\\":\\"/properties/0000---terrible-property-name~!3\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"0000---terrible-property-name~!3\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Sanitized',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7185,18 +7312,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<SimpleArrayTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Simple Array Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Simple Array Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients support fields with various types of arrays.\\",\\"labels\\":{},\\"properties\\":{\\"any\\":{\\"$id\\":\\"/properties/any\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\"},\\"type\\":\\"array\\"},\\"boolean\\":{\\"$id\\":\\"/properties/boolean\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/boolean/items\\",\\"description\\":\\"\\",\\"type\\":\\"boolean\\"},\\"type\\":\\"array\\"},\\"integer\\":{\\"$id\\":\\"/properties/integer\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/integer/items\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"type\\":\\"array\\"},\\"nullable\\":{\\"$id\\":\\"/properties/nullable\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/nullable/items\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"type\\":\\"array\\"},\\"number\\":{\\"$id\\":\\"/properties/number\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/number/items\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"type\\":\\"array\\"},\\"object\\":{\\"$id\\":\\"/properties/object\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/object/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/object/items/properties/name\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"string\\":{\\"$id\\":\\"/properties/string\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/string/items\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"type\\":\\"array\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Simple Array Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7213,18 +7341,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<UnionType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Union Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Union Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Validates that clients support fields with multiple (union) types.\\",\\"labels\\":{},\\"properties\\":{\\"universe_name\\":{\\"$id\\":\\"/properties/universe_name\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\",\\"integer\\"]}},\\"required\\":[\\"universe_name\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Union Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -7241,18 +7370,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NoIDType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'NoID type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"NoID Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"description\\":\\"Properties without IDs\\",\\"labels\\":{},\\"properties\\":{\\"no_id_prop\\":{\\"description\\":\\"a property without an ID\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"no_id_prop\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'NoID type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8096,7 +8226,7 @@ export interface UnionType {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv from 'ajv'
+import Ajv, { ErrorObject } from 'ajv'
 import AnalyticsNode from 'analytics-node'
 
 /**
@@ -8212,7 +8342,7 @@ export interface Context extends Record<string, any> {
 
 export type ViolationHandler = (
     message: TrackMessage<Record<string, any>>,
-    violations: Ajv.ErrorObject[]
+    violations: ErrorObject[]
 ) => void
 
 /**
@@ -8306,11 +8436,9 @@ function validateAgainstSchema(
     message: TrackMessage<Record<string, any>>,
     schema: object
 ) {
-    const ajv = new Ajv({ schemaId: 'auto', allErrors: true, verbose: true })
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+    const ajv = new Ajv({ allErrors: true, verbose: true })
 
-    if (!ajv.validate(schema, message) && ajv.errors) {
+    if (!ajv.validate(schema, message.properties) && ajv.errors) {
         onViolation(message, ajv.errors)
     }
 }
@@ -8328,7 +8456,7 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
             ...(message.context || {}),
             typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             },
         },
     }
@@ -8347,18 +8475,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<CustomViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Custom Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Custom Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Custom Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8375,18 +8504,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<DefaultViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Default Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Default Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Default Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8403,18 +8533,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EnumTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Enum Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Enum Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"string const\\":{\\"$id\\":\\"/properties/string%20const\\",\\"description\\":\\"A string property that only accepts a single enum value.\\",\\"enum\\":[\\"Rick Sanchez\\"],\\"type\\":\\"string\\"},\\"string enum\\":{\\"$id\\":\\"/properties/string%20enum\\",\\"description\\":\\"A string property that accepts multiple enum values.\\",\\"enum\\":[\\"Evil Morty\\",\\"Lawyer Morty\\"],\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Enum Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8431,18 +8562,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Nullable Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8459,18 +8591,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Nullable Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8487,18 +8620,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8515,18 +8649,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8543,18 +8678,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<LargeNumbersEvent>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Large Numbers Event',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Large Numbers Event\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"large nullable optional integer\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable optional number\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large nullable required integer\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable required number\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large optional integer\\":{\\"$id\\":\\"/properties/large%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large optional number\\":{\\"$id\\":\\"/properties/large%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"large required integer\\":{\\"$id\\":\\"/properties/large%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large required number\\":{\\"$id\\":\\"/properties/large%20required%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"}},\\"required\\":[\\"large required integer\\",\\"large required number\\",\\"large nullable required integer\\",\\"large nullable required number\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Large Numbers Event',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8571,18 +8707,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedArrays>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Arrays',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Nested Arrays\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universeCharacters\\":{\\"$id\\":\\"/properties/universeCharacters\\",\\"description\\":\\"All known characters from each universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universeCharacters/items\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items\\",\\"properties\\":{\\"name\\":{\\"description\\":\\"The character's name.\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items/properties/name\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"universeCharacters\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Arrays',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8599,18 +8736,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedObjects>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Objects',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Nested Objects\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"garage\\":{\\"$id\\":\\"/properties/garage\\",\\"description\\":\\"\\",\\"properties\\":{\\"tunnel\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel\\",\\"description\\":\\"\\",\\"properties\\":{\\"subterranean lab\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab\\",\\"description\\":\\"\\",\\"properties\\":{\\"jerry's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/jerry's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"morty's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/morty's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"summer's contingency plan\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/summer's%20contingency%20plan\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"}},\\"required\\":[\\"subterranean lab\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"tunnel\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"garage\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Objects',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8627,18 +8765,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertiesCollided>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Properties Collided',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Properties Collided\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"Property Collided\\":{\\"$id\\":\\"/properties/Property%20Collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"property_collided\\":{\\"$id\\":\\"/properties/property_collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"property_collided\\",\\"Property Collided\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Properties Collided',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8655,18 +8794,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision1>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #1',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Object Name Collision 1\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #1',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8683,18 +8823,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision2>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #2',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Object Name Collision 2\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #2',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8711,18 +8852,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertySanitized>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Sanitized',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Sanitized\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"0000---terrible-property-name~!3\\":{\\"$id\\":\\"/properties/0000---terrible-property-name~!3\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"0000---terrible-property-name~!3\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Sanitized',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8739,18 +8881,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<SimpleArrayTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Simple Array Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Simple Array Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"any\\":{\\"$id\\":\\"/properties/any\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\"},\\"type\\":\\"array\\"},\\"boolean\\":{\\"$id\\":\\"/properties/boolean\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/boolean/items\\",\\"description\\":\\"\\",\\"type\\":\\"boolean\\"},\\"type\\":\\"array\\"},\\"integer\\":{\\"$id\\":\\"/properties/integer\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/integer/items\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"type\\":\\"array\\"},\\"nullable\\":{\\"$id\\":\\"/properties/nullable\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/nullable/items\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"type\\":\\"array\\"},\\"number\\":{\\"$id\\":\\"/properties/number\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/number/items\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"type\\":\\"array\\"},\\"object\\":{\\"$id\\":\\"/properties/object\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/object/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/object/items/properties/name\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"string\\":{\\"$id\\":\\"/properties/string\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/string/items\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"type\\":\\"array\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Simple Array Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -8767,18 +8910,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<UnionType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Union Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Union Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universe_name\\":{\\"$id\\":\\"/properties/universe_name\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\",\\"integer\\"]}},\\"required\\":[\\"universe_name\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Union Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -9612,7 +9756,7 @@ export interface UnionType {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv from 'ajv'
+import Ajv, { ErrorObject } from 'ajv'
 import AnalyticsNode from 'analytics-node'
 
 /**
@@ -9728,7 +9872,7 @@ export interface Context extends Record<string, any> {
 
 export type ViolationHandler = (
     message: TrackMessage<Record<string, any>>,
-    violations: Ajv.ErrorObject[]
+    violations: ErrorObject[]
 ) => void
 
 /**
@@ -9822,11 +9966,9 @@ function validateAgainstSchema(
     message: TrackMessage<Record<string, any>>,
     schema: object
 ) {
-    const ajv = new Ajv({ schemaId: 'auto', allErrors: true, verbose: true })
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
-    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+    const ajv = new Ajv({ allErrors: true, verbose: true })
 
-    if (!ajv.validate(schema, message) && ajv.errors) {
+    if (!ajv.validate(schema, message.properties) && ajv.errors) {
         onViolation(message, ajv.errors)
     }
 }
@@ -9844,7 +9986,7 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
             ...(message.context || {}),
             typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             },
         },
     }
@@ -9863,18 +10005,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<CustomViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Custom Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Custom Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Custom Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -9891,18 +10034,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<DefaultViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Default Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Default Violation Handler\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"regex property\\":{\\"$id\\":\\"/properties/regex%20property\\",\\"description\\":\\"\\",\\"pattern\\":\\"Lawyer Morty|Evil Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"regex property\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Default Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -9919,18 +10063,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EnumTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Enum Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Enum Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"string const\\":{\\"$id\\":\\"/properties/string%20const\\",\\"description\\":\\"A string property that only accepts a single enum value.\\",\\"enum\\":[\\"Rick Sanchez\\"],\\"type\\":\\"string\\"},\\"string enum\\":{\\"$id\\":\\"/properties/string%20enum\\",\\"description\\":\\"A string property that accepts multiple enum values.\\",\\"enum\\":[\\"Evil Morty\\",\\"Lawyer Morty\\"],\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Enum Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -9947,18 +10092,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Nullable Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -9975,18 +10121,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Nullable Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":[\\"array\\",\\"null\\"]},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":[\\"boolean\\",\\"null\\"]},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"properties\\":{},\\"required\\":[],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":[\\"object\\",\\"null\\"]},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":[\\"string\\",\\"null\\"]}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10003,18 +10150,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Optional Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional array with properties\\":{\\"$id\\":\\"/properties/optional%20array%20with%20properties\\",\\"description\\":\\"Optional array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20array%20with%20properties/items/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional object with properties\\":{\\"$id\\":\\"/properties/optional%20object%20with%20properties\\",\\"description\\":\\"Optional object with properties\\",\\"properties\\":{\\"optional any\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20any\\",\\"description\\":\\"Optional any property\\"},\\"optional array\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20array\\",\\"description\\":\\"Optional array property\\",\\"type\\":\\"array\\"},\\"optional boolean\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20boolean\\",\\"description\\":\\"Optional boolean property\\",\\"type\\":\\"boolean\\"},\\"optional int\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20int\\",\\"description\\":\\"Optional integer property\\",\\"type\\":\\"integer\\"},\\"optional number\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20number\\",\\"description\\":\\"Optional number property\\",\\"type\\":\\"number\\"},\\"optional object\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20object\\",\\"description\\":\\"Optional object property\\",\\"key\\":\\"optional object\\",\\"properties\\":{},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/properties/properties/optional%20object%20with%20properties/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"},\\"optional string\\":{\\"$id\\":\\"/properties/optional%20string\\",\\"description\\":\\"Optional string property\\",\\"type\\":\\"string\\"},\\"optional string with regex\\":{\\"$id\\":\\"/properties/optional%20string%20with%20regex\\",\\"description\\":\\"Optional string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10031,18 +10179,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Every Required Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required array with properties\\":{\\"$id\\":\\"/properties/required%20array%20with%20properties\\",\\"description\\":\\"Required array with properties\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20array%20with%20properties/items/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required object with properties\\":{\\"$id\\":\\"/properties/required%20object%20with%20properties\\",\\"description\\":\\"Required object with properties\\",\\"properties\\":{\\"required any\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20any\\",\\"description\\":\\"Required any property\\"},\\"required array\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20array\\",\\"description\\":\\"Required array property\\",\\"type\\":\\"array\\"},\\"required boolean\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20boolean\\",\\"description\\":\\"Required boolean property\\",\\"type\\":\\"boolean\\"},\\"required int\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20int\\",\\"description\\":\\"Required integer property\\",\\"type\\":\\"integer\\"},\\"required number\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20number\\",\\"description\\":\\"Required number property\\",\\"type\\":\\"number\\"},\\"required object\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20object\\",\\"description\\":\\"Required object property\\",\\"key\\":\\"required object\\",\\"properties\\":{},\\"required\\":[],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/properties/properties/required%20object%20with%20properties/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\"],\\"type\\":\\"object\\"},\\"required string\\":{\\"$id\\":\\"/properties/required%20string\\",\\"description\\":\\"Required string property\\",\\"type\\":\\"string\\"},\\"required string with regex\\":{\\"$id\\":\\"/properties/required%20string%20with%20regex\\",\\"description\\":\\"Required string property with a regex conditional\\",\\"pattern\\":\\"Evil Morty|Lawyer Morty\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"required any\\",\\"required array\\",\\"required boolean\\",\\"required int\\",\\"required number\\",\\"required object\\",\\"required string\\",\\"required string with regex\\",\\"required object with properties\\",\\"required array with properties\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10059,18 +10208,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<LargeNumbersEvent>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Large Numbers Event',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Large Numbers Event\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"large nullable optional integer\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable optional number\\":{\\"$id\\":\\"/properties/large%20nullable%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large nullable required integer\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":[\\"integer\\",\\"null\\"]},\\"large nullable required number\\":{\\"$id\\":\\"/properties/large%20nullable%20required%20number\\",\\"description\\":\\"\\",\\"type\\":[\\"number\\",\\"null\\"]},\\"large optional integer\\":{\\"$id\\":\\"/properties/large%20optional%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large optional number\\":{\\"$id\\":\\"/properties/large%20optional%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"large required integer\\":{\\"$id\\":\\"/properties/large%20required%20integer\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"large required number\\":{\\"$id\\":\\"/properties/large%20required%20number\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"}},\\"required\\":[\\"large required integer\\",\\"large required number\\",\\"large nullable required integer\\",\\"large nullable required number\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Large Numbers Event',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10087,18 +10237,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedArrays>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Arrays',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Nested Arrays\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universeCharacters\\":{\\"$id\\":\\"/properties/universeCharacters\\",\\"description\\":\\"All known characters from each universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universeCharacters/items\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items\\",\\"properties\\":{\\"name\\":{\\"description\\":\\"The character's name.\\",\\"id\\":\\"/properties/properties/properties/universeCharacters/items/items/properties/name\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"universeCharacters\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Arrays',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10115,18 +10266,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedObjects>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Objects',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Nested Objects\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"garage\\":{\\"$id\\":\\"/properties/garage\\",\\"description\\":\\"\\",\\"properties\\":{\\"tunnel\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel\\",\\"description\\":\\"\\",\\"properties\\":{\\"subterranean lab\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab\\",\\"description\\":\\"\\",\\"properties\\":{\\"jerry's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/jerry's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"morty's memories\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/morty's%20memories\\",\\"description\\":\\"\\",\\"type\\":\\"array\\"},\\"summer's contingency plan\\":{\\"$id\\":\\"/properties/properties/properties/garage/properties/tunnel/properties/subterranean%20lab/properties/summer's%20contingency%20plan\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"}},\\"required\\":[\\"subterranean lab\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"tunnel\\"],\\"type\\":\\"object\\"}},\\"required\\":[\\"garage\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Objects',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10143,18 +10295,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertiesCollided>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Properties Collided',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Properties Collided\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"Property Collided\\":{\\"$id\\":\\"/properties/Property%20Collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"property_collided\\":{\\"$id\\":\\"/properties/property_collided\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"property_collided\\",\\"Property Collided\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Properties Collided',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10171,18 +10324,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision1>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #1',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Object Name Collision 1\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #1',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10199,18 +10353,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision2>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #2',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Object Name Collision 2\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universe\\":{\\"$id\\":\\"/properties/universe\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/name\\",\\"description\\":\\"The common name of this universe.\\",\\"type\\":\\"string\\"},\\"occupants\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants\\",\\"description\\":\\"The most important occupants in this universe.\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/universe/properties/occupants/items/properties/name\\",\\"description\\":\\"The name of this occupant.\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"name\\"],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"}},\\"required\\":[\\"name\\",\\"occupants\\"],\\"type\\":\\"object\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #2',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10227,18 +10382,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertySanitized>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Sanitized',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Property Sanitized\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"0000---terrible-property-name~!3\\":{\\"$id\\":\\"/properties/0000---terrible-property-name~!3\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[\\"0000---terrible-property-name~!3\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Sanitized',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10255,18 +10411,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<SimpleArrayTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Simple Array Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Simple Array Types\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"any\\":{\\"$id\\":\\"/properties/any\\",\\"description\\":\\"\\",\\"items\\":{\\"description\\":\\"\\"},\\"type\\":\\"array\\"},\\"boolean\\":{\\"$id\\":\\"/properties/boolean\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/boolean/items\\",\\"description\\":\\"\\",\\"type\\":\\"boolean\\"},\\"type\\":\\"array\\"},\\"integer\\":{\\"$id\\":\\"/properties/integer\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/integer/items\\",\\"description\\":\\"\\",\\"type\\":\\"integer\\"},\\"type\\":\\"array\\"},\\"nullable\\":{\\"$id\\":\\"/properties/nullable\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/nullable/items\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\"]},\\"type\\":\\"array\\"},\\"number\\":{\\"$id\\":\\"/properties/number\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/number/items\\",\\"description\\":\\"\\",\\"type\\":\\"number\\"},\\"type\\":\\"array\\"},\\"object\\":{\\"$id\\":\\"/properties/object\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/object/items\\",\\"description\\":\\"\\",\\"properties\\":{\\"name\\":{\\"$id\\":\\"/properties/properties/properties/object/items/properties/name\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"}},\\"required\\":[],\\"type\\":\\"object\\"},\\"type\\":\\"array\\"},\\"string\\":{\\"$id\\":\\"/properties/string\\",\\"description\\":\\"\\",\\"items\\":{\\"$id\\":\\"/properties/properties/properties/string/items\\",\\"description\\":\\"\\",\\"type\\":\\"string\\"},\\"type\\":\\"array\\"}},\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Simple Array Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -10283,18 +10440,19 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<UnionType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Union Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+    const schema = {\\"$id\\":\\"Union Type\\",\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\",\\"labels\\":{},\\"properties\\":{\\"universe_name\\":{\\"$id\\":\\"/properties/universe_name\\",\\"description\\":\\"\\",\\"type\\":[\\"string\\",\\"null\\",\\"integer\\"]}},\\"required\\":[\\"universe_name\\"],\\"type\\":\\"object\\"};
+    validateAgainstSchema(event, schema);
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Union Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }

--- a/src/__tests__/commands/__snapshots__/production.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/production.test.ts.snap
@@ -852,7 +852,7 @@ function withTypewriterContext(message: Options = {}): Options {
             ...(message.context || {}),
             typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             },
         },
     };
@@ -867,6 +867,8 @@ function withTypewriterContext(message: Options = {}): Options {
  * 	call is fired.
  */
 export function customViolationHandler(props: CustomViolationHandler, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Custom Violation Handler', props || {}, {...options,   context: {
@@ -887,6 +889,8 @@ export function customViolationHandler(props: CustomViolationHandler, options?: 
  * 	call is fired.
  */
 export function defaultViolationHandler(props: DefaultViolationHandler, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Default Violation Handler', props || {}, {...options,   context: {
@@ -907,6 +911,8 @@ export function defaultViolationHandler(props: DefaultViolationHandler, options?
  * 	call is fired.
  */
 export function enumTypes(props: EnumTypes, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Enum Types', props || {}, {...options,   context: {
@@ -927,6 +933,8 @@ export function enumTypes(props: EnumTypes, options?: Options, callback?: Callba
  * 	call is fired.
  */
 export function everyNullableOptionalType(props: EveryNullableOptionalType, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Every Nullable Optional Type', props || {}, {...options,   context: {
@@ -947,6 +955,8 @@ export function everyNullableOptionalType(props: EveryNullableOptionalType, opti
  * 	call is fired.
  */
 export function everyNullableRequiredType(props: EveryNullableRequiredType, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Every Nullable Required Type', props || {}, {...options,   context: {
@@ -967,6 +977,8 @@ export function everyNullableRequiredType(props: EveryNullableRequiredType, opti
  * 	call is fired.
  */
 export function everyOptionalType(props: EveryOptionalType, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Every Optional Type', props || {}, {...options,   context: {
@@ -987,6 +999,8 @@ export function everyOptionalType(props: EveryOptionalType, options?: Options, c
  * 	call is fired.
  */
 export function everyRequiredType(props: EveryRequiredType, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Every Required Type', props || {}, {...options,   context: {
@@ -1007,6 +1021,8 @@ export function everyRequiredType(props: EveryRequiredType, options?: Options, c
  * 	call is fired.
  */
 export function largeNumbersEvent(props: LargeNumbersEvent, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Large Numbers Event', props || {}, {...options,   context: {
@@ -1027,6 +1043,8 @@ export function largeNumbersEvent(props: LargeNumbersEvent, options?: Options, c
  * 	call is fired.
  */
 export function nestedArrays(props: NestedArrays, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Nested Arrays', props || {}, {...options,   context: {
@@ -1047,6 +1065,8 @@ export function nestedArrays(props: NestedArrays, options?: Options, callback?: 
  * 	call is fired.
  */
 export function nestedObjects(props: NestedObjects, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Nested Objects', props || {}, {...options,   context: {
@@ -1067,6 +1087,8 @@ export function nestedObjects(props: NestedObjects, options?: Options, callback?
  * 	call is fired.
  */
 export function propertiesCollided(props: PropertiesCollided, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Properties Collided', props || {}, {...options,   context: {
@@ -1087,6 +1109,8 @@ export function propertiesCollided(props: PropertiesCollided, options?: Options,
  * 	call is fired.
  */
 export function propertyObjectNameCollision1(props: PropertyObjectNameCollision1, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Property Object Name Collision #1', props || {}, {...options,   context: {
@@ -1107,6 +1131,8 @@ export function propertyObjectNameCollision1(props: PropertyObjectNameCollision1
  * 	call is fired.
  */
 export function propertyObjectNameCollision2(props: PropertyObjectNameCollision2, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Property Object Name Collision #2', props || {}, {...options,   context: {
@@ -1127,6 +1153,8 @@ export function propertyObjectNameCollision2(props: PropertyObjectNameCollision2
  * 	call is fired.
  */
 export function propertySanitized(props: PropertySanitized, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Property Sanitized', props || {}, {...options,   context: {
@@ -1147,6 +1175,8 @@ export function propertySanitized(props: PropertySanitized, options?: Options, c
  * 	call is fired.
  */
 export function simpleArrayTypes(props: SimpleArrayTypes, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Simple Array Types', props || {}, {...options,   context: {
@@ -1167,6 +1197,8 @@ export function simpleArrayTypes(props: SimpleArrayTypes, options?: Options, cal
  * 	call is fired.
  */
 export function unionType(props: UnionType, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('Union Type', props || {}, {...options,   context: {
@@ -1187,6 +1219,8 @@ export function unionType(props: UnionType, options?: Options, callback?: Callba
  * 	call is fired.
  */
 export function noIDType(props: NoIDType, options?: Options, callback?: Callback): void {
+
+
     const a = analytics();
     if (a) {
         a.track('NoID type', props || {}, {...options,   context: {
@@ -2283,7 +2317,7 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
             ...(message.context || {}),
             typewriter: {
                 language: 'typescript',
-                version: '8.0.6',
+                version: '8.0.8',
             },
         },
     }
@@ -2302,18 +2336,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<CustomViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Custom Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Custom Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2330,18 +2363,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<DefaultViolationHandler>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Default Violation Handler',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Default Violation Handler',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2358,18 +2390,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EnumTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Enum Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Enum Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2386,18 +2417,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2414,18 +2444,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryNullableRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Nullable Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Nullable Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2442,18 +2471,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryOptionalType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Optional Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Optional Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2470,18 +2498,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<EveryRequiredType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Every Required Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Every Required Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2498,18 +2525,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<LargeNumbersEvent>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Large Numbers Event',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Large Numbers Event',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2526,18 +2552,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedArrays>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Arrays',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Arrays',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2554,18 +2579,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NestedObjects>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Nested Objects',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Nested Objects',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2582,18 +2606,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertiesCollided>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Properties Collided',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Properties Collided',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2610,18 +2633,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision1>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #1',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #1',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2638,18 +2660,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertyObjectNameCollision2>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Object Name Collision #2',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Object Name Collision #2',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2666,18 +2687,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<PropertySanitized>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Property Sanitized',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Property Sanitized',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2694,18 +2714,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<SimpleArrayTypes>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Simple Array Types',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Simple Array Types',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2722,18 +2741,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<UnionType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'Union Type',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'Union Type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }
@@ -2750,18 +2768,17 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
     message: TrackMessage<NoIDType>,
     callback?: Callback
 ): void {
+    const event = withTypewriterContext({
+        ...message,
+        event: 'NoID type',
+        properties: {
+            ...message.properties,
+        },
+    });
+
     const a = analytics()
     if (a) {
-        a.track(
-            withTypewriterContext({
-                ...message,
-                event: 'NoID type',
-                properties: {
-                    ...message.properties,
-                },
-            }),
-            callback,
-        );
+        a.track(event,callback);
     } else {
         throw missingAnalyticsNodeError
     }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -83,6 +83,7 @@ export namespace SegmentAPI {
   }
 
   export type RuleMetadata = {
+    $id?: string;
     key: string;
     type: RuleType;
     description?: string;

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -121,7 +121,7 @@ export abstract class BaseCommand extends Command {
       error: err,
       rawCommand: this.argv.join(" "),
       errorCode: err.exitCode,
-      isCI: this.isCI,
+      isCI: `${this.isCI}`,
     } as CommandError);
     // We do a flush here manually cause oclif doesn't run the postrun hook for errors
     try {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -204,7 +204,7 @@ export default class Build extends BaseCommand {
           this.workspaceConfig,
           this.tokenMetadata?.method
         ),
-        isCI: this.isCI,
+        isCI: `${this.isCI}`,
         mode: flags.mode === "dev" ? Mode.Dev : Mode.Prod,
         workspace: this.workspace?.id,
         duration: process.hrtime(startTime)[1],

--- a/src/languages/quicktype-utils.ts
+++ b/src/languages/quicktype-utils.ts
@@ -227,7 +227,7 @@ function createCodeGeneratorFromTemplate(
           const metadata: EventMetadata = type
             .getAttributes()
             .get(eventMetadataAttributeKind);
-          console.log(metadata);
+
           tags.type.push({
             eventName: metadata.name,
             eventType: metadata.type,
@@ -369,9 +369,11 @@ function eventAttributesProducer(
   if (typeof schema !== "object" || schema.eventMetadata === undefined)
     return undefined;
 
+  // Remove the eventMetadata from the raw schema
+  const { eventMetadata, ...rawSchema } = schema;
   const metadata = eventMetadataAttributeKind.makeAttributes({
     ...schema.eventMetadata,
-    raw: schema,
+    raw: rawSchema,
   });
 
   return { forType: metadata };

--- a/src/languages/quicktype-utils.ts
+++ b/src/languages/quicktype-utils.ts
@@ -1,9 +1,9 @@
-import { debug as debugRegister } from 'debug';
-import * as fs from 'fs';
-import Handlebars from 'handlebars';
-import { DistinctQuestion } from 'inquirer';
-import { EOL } from 'os';
-import { resolve } from 'path';
+import { debug as debugRegister } from "debug";
+import * as fs from "fs";
+import Handlebars from "handlebars";
+import { DistinctQuestion } from "inquirer";
+import { EOL } from "os";
+import { resolve } from "path";
 import {
   ConvenienceRenderer,
   getTargetLanguage,
@@ -21,10 +21,10 @@ import {
   TargetLanguage,
   Type,
   TypeAttributeKind,
-} from 'quicktype-core';
-import { originalWord } from 'quicktype-core/dist/support/Strings';
-import { isNamedType } from 'quicktype-core/dist/TypeUtils';
-import { SegmentAPI } from '../api';
+} from "quicktype-core";
+import { originalWord } from "quicktype-core/dist/support/Strings";
+import { isNamedType } from "quicktype-core/dist/TypeUtils";
+import { SegmentAPI } from "../api";
 import {
   CodeGenerator,
   FileGenerateResult,
@@ -32,14 +32,14 @@ import {
   LanguageGenerator,
   QuicktypeTypewriterSettings,
   TemplateContext,
-} from './types';
+} from "./types";
 
-const debug = debugRegister('typewriter:quicktype-utils');
+const debug = debugRegister("typewriter:quicktype-utils");
 
 const INDENT_SIZE = 4;
 
 function addPrefixAndSuffix(name: string, prefix?: string, suffix?: string) {
-  return `${prefix ?? ''} ${name} ${suffix ?? ''}`;
+  return `${prefix ?? ""} ${name} ${suffix ?? ""}`;
 }
 
 /**
@@ -48,7 +48,7 @@ function addPrefixAndSuffix(name: string, prefix?: string, suffix?: string) {
 const modWithPrefixAndSuffix = (
   prefix?: string,
   suffix?: string,
-  modifier?: (name: string) => string,
+  modifier?: (name: string) => string
 ): ((name: string) => string) => {
   return (name: string) => {
     const modName = addPrefixAndSuffix(name, prefix, suffix);
@@ -67,7 +67,7 @@ export function makeNameForTopLevelWithPrefixAndSuffix(
   typewriterSettings: QuicktypeTypewriterSettings,
   t: Type,
   givenName: string,
-  maybeNamedType?: Type,
+  maybeNamedType?: Type
 ): Name {
   const { prefix, suffix } = typewriterSettings.typeNameModifiers ?? {};
   const modName = addPrefixAndSuffix(givenName, prefix, suffix);
@@ -86,7 +86,7 @@ function toInquirerQuestion(option: OptionDefinition): DistinctQuestion {
   // Option setting
   if (option.legalValues !== undefined && option.legalValues.length > 0) {
     return {
-      type: option.multiple ? 'checkbox' : 'list',
+      type: option.multiple ? "checkbox" : "list",
       name: option.name,
       message: option.description,
       choices: option.legalValues,
@@ -97,7 +97,7 @@ function toInquirerQuestion(option: OptionDefinition): DistinctQuestion {
   // String setting
   if (option.type === String) {
     return {
-      type: 'input',
+      type: "input",
       name: option.name,
       message: option.description,
       default: option.defaultValue,
@@ -106,7 +106,7 @@ function toInquirerQuestion(option: OptionDefinition): DistinctQuestion {
 
   // Boolean Option
   return {
-    type: 'confirm',
+    type: "confirm",
     name: option.name,
     message: option.description,
     default: option.defaultValue,
@@ -122,7 +122,7 @@ function toInquirerQuestion(option: OptionDefinition): DistinctQuestion {
 export function getLanguageMetadata(
   language: string,
   unsupportedOptions: string[] = [],
-  requiredOptions: string[] = [],
+  requiredOptions: string[] = []
 ): LanguageMetadata {
   const lang = getTargetLanguage(language);
 
@@ -159,15 +159,15 @@ export function getLanguageMetadata(
  */
 export function calculateLineIndentationLevel(
   line: string,
-  indentSize: number = INDENT_SIZE,
+  indentSize: number = INDENT_SIZE
 ): { indent: number; text: string | null } {
   const len = line.length;
   let indent = 0;
   for (let i = 0; i < len; i++) {
     const c = line.charAt(i);
-    if (c === ' ') {
+    if (c === " ") {
       indent += 1;
-    } else if (c === '\t') {
+    } else if (c === "\t") {
       indent = (indent / indentSize + 1) * indentSize;
     } else {
       return { indent, text: line.substring(i) };
@@ -191,7 +191,9 @@ export function createCodeGeneratorsFromTemplates(
   nameModifiers?: NameModifiers,
   ...paths: string[]
 ): CodeGenerator[] {
-  return paths.map((path) => createCodeGeneratorFromTemplate(path, context, nameModifiers));
+  return paths.map((path) =>
+    createCodeGeneratorFromTemplate(path, context, nameModifiers)
+  );
 }
 
 /**
@@ -203,12 +205,12 @@ export function createCodeGeneratorsFromTemplates(
 function createCodeGeneratorFromTemplate(
   path: string,
   context: TemplateContext,
-  nameModifiers?: NameModifiers,
+  nameModifiers?: NameModifiers
 ): CodeGenerator {
   const absolutePath = resolve(__dirname, path);
   try {
     const template = fs.readFileSync(absolutePath);
-    Handlebars.registerHelper('eq', (a, b) => a === b);
+    Handlebars.registerHelper("eq", (a, b) => a === b);
     const generator = Handlebars.compile(template.toString());
 
     return (renderer) => {
@@ -220,27 +222,37 @@ function createCodeGeneratorFromTemplate(
 
       // @ts-ignore this is a protected method but we need it to access the particulars of each type
       renderer.forEachTopLevel(
-        'none',
+        "none",
         (type, name) => {
-          const metadata: EventMetadata = type.getAttributes().get(eventMetadataAttributeKind);
+          const metadata: EventMetadata = type
+            .getAttributes()
+            .get(eventMetadataAttributeKind);
+          console.log(metadata);
           tags.type.push({
             eventName: metadata.name,
             eventType: metadata.type,
             // @ts-ignore
-            description: renderer.descriptionForType(type)?.join(' '),
+            description: renderer.descriptionForType(type)?.join(" "),
             // @ts-ignore
-            functionName: renderer.sourcelikeToString(modifySource(nameModifiers?.functionName ?? originalWord, name)),
+            functionName: renderer.sourcelikeToString(
+              modifySource(nameModifiers?.functionName ?? originalWord, name)
+            ),
             // @ts-ignore
             typeName: renderer.sourcelikeToString(name),
+            rawJSONSchema: JSON.stringify(metadata.raw),
           });
         },
-        isNamedType,
+        isNamedType
       );
 
       return renderer.emitMultiline(generator(tags));
     };
   } catch (error) {
-    throw new Error(`Error while reading template at ${absolutePath}: ${JSON.stringify(error)}`);
+    throw new Error(
+      `Error while reading template at ${absolutePath}: ${JSON.stringify(
+        error
+      )}`
+    );
   }
 }
 
@@ -251,8 +263,12 @@ function createCodeGeneratorFromTemplate(
  * @param indentSize indent size in spaces number
  * @returns
  */
-export function emitMultiline(renderer: ConvenienceRenderer, linesString: string, indentSize: number = 4): void {
-  const lines = linesString.split('\n');
+export function emitMultiline(
+  renderer: ConvenienceRenderer,
+  linesString: string,
+  indentSize: number = 4
+): void {
+  const lines = linesString.split("\n");
   const numLines = lines.length;
   if (numLines === 0) return;
   renderer.emitLine(lines[0]);
@@ -265,7 +281,7 @@ export function emitMultiline(renderer: ConvenienceRenderer, linesString: string
       const leadSpaces = indent % indentSize;
       renderer.changeIndent(newIndent - currentIndent);
       currentIndent = newIndent;
-      renderer.emitLine(' '.repeat(leadSpaces), text);
+      renderer.emitLine(" ".repeat(leadSpaces), text);
     } else {
       renderer.emitLine();
     }
@@ -281,7 +297,10 @@ export function emitMultiline(renderer: ConvenienceRenderer, linesString: string
  * @param templatePlan an array of CodeGenerator functions to execute
  * @param nameModifiers Name Modifiers to apply for functions and types
  */
-export function executeRenderPlan(renderer: ConvenienceRenderer, templatePlan: CodeGenerator[]): void {
+export function executeRenderPlan(
+  renderer: ConvenienceRenderer,
+  templatePlan: CodeGenerator[]
+): void {
   if (templatePlan.length === 0) {
     return;
   }
@@ -303,10 +322,12 @@ export function executeRenderPlan(renderer: ConvenienceRenderer, templatePlan: C
 export function cleanOptions(
   options: GeneratorOptions,
   defaultValues: { [key: string]: any } = {},
-  unsupportedOptions: string[] = [],
+  unsupportedOptions: string[] = []
 ): GeneratorOptions {
   const filteredOptions = Object.fromEntries(
-    Object.entries(options).filter(([key, _]) => !unsupportedOptions.includes(key as string)),
+    Object.entries(options).filter(
+      ([key, _]) => !unsupportedOptions.includes(key as string)
+    )
   );
   return {
     ...defaultValues,
@@ -317,11 +338,12 @@ export function cleanOptions(
 interface EventMetadata {
   name: string;
   type: SegmentAPI.RuleType;
+  raw: JSONSchema;
 }
 
 class EventMetadataAttributeKind extends TypeAttributeKind<EventMetadata> {
   constructor() {
-    super('eventMetadata');
+    super("eventMetadata");
   }
 
   combine(attrs: EventMetadata[]): EventMetadata | undefined {
@@ -333,7 +355,8 @@ class EventMetadataAttributeKind extends TypeAttributeKind<EventMetadata> {
   }
 }
 
-const eventMetadataAttributeKind: TypeAttributeKind<EventMetadata> = new EventMetadataAttributeKind();
+const eventMetadataAttributeKind: TypeAttributeKind<EventMetadata> =
+  new EventMetadataAttributeKind();
 
 /**
  * Extracts and injects the event metadata into the attributes for the quicktype types
@@ -341,11 +364,15 @@ const eventMetadataAttributeKind: TypeAttributeKind<EventMetadata> = new EventMe
 function eventAttributesProducer(
   schema: JSONSchema,
   _canonicalRef: Ref | undefined,
-  _types: Set<JSONSchemaType>,
+  _types: Set<JSONSchemaType>
 ): JSONSchemaAttributes | undefined {
-  if (typeof schema !== 'object' || schema.eventMetadata === undefined) return undefined;
+  if (typeof schema !== "object" || schema.eventMetadata === undefined)
+    return undefined;
 
-  const metadata = eventMetadataAttributeKind.makeAttributes(schema.eventMetadata);
+  const metadata = eventMetadataAttributeKind.makeAttributes({
+    ...schema.eventMetadata,
+    raw: schema,
+  });
 
   return { forType: metadata };
 }
@@ -355,10 +382,15 @@ function eventAttributesProducer(
  * @param rules Segment PublicAPI Rules object
  * @returns InputData object for Quicktype to read as a JSON Schema
  */
-async function getSchemaInputData(rules: SegmentAPI.RuleMetadata[]): Promise<InputData> {
+async function getSchemaInputData(
+  rules: SegmentAPI.RuleMetadata[]
+): Promise<InputData> {
   const schemaInput = new JSONSchemaInput(undefined, [eventAttributesProducer]);
   for (const rule of rules ?? []) {
-    await schemaInput.addSource({ name: rule.key, schema: JSON.stringify(rule.jsonSchema) });
+    await schemaInput.addSource({
+      name: rule.key,
+      schema: JSON.stringify(rule.jsonSchema),
+    });
   }
   const inputData = new InputData();
   inputData.addInput(schemaInput);
@@ -375,7 +407,7 @@ async function getSchemaInputData(rules: SegmentAPI.RuleMetadata[]): Promise<Inp
 export async function generateWithQuicktype(
   language: string | TargetLanguage,
   rules: SegmentAPI.RuleMetadata[],
-  options: GeneratorOptions,
+  options: GeneratorOptions
 ): Promise<FileGenerateResult> {
   const { header, sdk, outputFilename, ...rendererOptions } = options;
   const inputData = await getSchemaInputData(rules);
@@ -454,11 +486,22 @@ interface FactoryConfig<T extends TargetLanguage> {
  * @returns a LanguageGenerator object for Typewriter
  */
 export function createQuicktypeLanguageGenerator<T extends TargetLanguage>(
-  config: FactoryConfig<T>,
+  config: FactoryConfig<T>
 ): LanguageGenerator {
-  const { name, quicktypeLanguage, supportedSDKs, defaultOptions, unsupportedOptions, nameModifiers, requiredOptions } =
-    config;
-  const metadata = getLanguageMetadata(name, unsupportedOptions, requiredOptions);
+  const {
+    name,
+    quicktypeLanguage,
+    supportedSDKs,
+    defaultOptions,
+    unsupportedOptions,
+    nameModifiers,
+    requiredOptions,
+  } = config;
+  const metadata = getLanguageMetadata(
+    name,
+    unsupportedOptions,
+    requiredOptions
+  );
 
   const sdks: { [key: string]: string } = {};
   const templates: { [key: string]: string | undefined } = {};
@@ -479,20 +522,20 @@ export function createQuicktypeLanguageGenerator<T extends TargetLanguage>(
     generate: async (
       rules: SegmentAPI.RuleMetadata[],
       context: TemplateContext,
-      options: GeneratorOptions,
+      options: GeneratorOptions
     ): Promise<FileGenerateResult> => {
       const { sdk, prefixes, suffixes } = options;
       let codeGenerators: CodeGenerator[];
       const templatePath = templates[sdk.toLocaleLowerCase()];
       debug(
-        'Starting Quicktype Generator for SDK:',
+        "Starting Quicktype Generator for SDK:",
         sdk,
-        'Language:',
+        "Language:",
         metadata.name,
-        'Template Path:',
+        "Template Path:",
         templatePath,
-        'Options',
-        options,
+        "Options",
+        options
       );
       if (templatePath === undefined) {
         codeGenerators = [];
@@ -502,10 +545,14 @@ export function createQuicktypeLanguageGenerator<T extends TargetLanguage>(
           functionName: modWithPrefixAndSuffix(
             prefixes?.functionName,
             suffixes?.functionName,
-            nameModifiers?.functionName,
+            nameModifiers?.functionName
           ),
         };
-        codeGenerators = createCodeGeneratorsFromTemplates(context, mods, templatePath);
+        codeGenerators = createCodeGeneratorsFromTemplates(
+          context,
+          mods,
+          templatePath
+        );
         debug(`Generate ${metadata.name} using template: ${templatePath}`);
       }
 
@@ -518,7 +565,7 @@ export function createQuicktypeLanguageGenerator<T extends TargetLanguage>(
           },
         }),
         rules,
-        cleanOptions(options, defaultOptions, unsupportedOptions),
+        cleanOptions(options, defaultOptions, unsupportedOptions)
       );
     },
   };

--- a/src/languages/templates/typescript/analytics-js.hbs
+++ b/src/languages/templates/typescript/analytics-js.hbs
@@ -7,7 +7,7 @@
  * 
  * You can install it with: `npm install --save-dev ajv`.
  */
-import Ajv from 'ajv'
+import Ajv, { ErrorObject } from 'ajv'
 {{/if}}
 
 /**
@@ -114,7 +114,7 @@ export interface Context extends Record<string, any> {
 export type ViolationHandler = (
 	message: Record<string, any>,
 	{{!-- Swap the type definitions here so we don't want depend on ajv in production just for this type definition. --}}
-	violations: {{#if isDevelopment}}Ajv.ErrorObject{{else}}any{{/if}}[]
+	violations: {{#if isDevelopment}}ErrorObject{{else}}any{{/if}}[]
 ) => void
 
 /**
@@ -192,9 +192,7 @@ function validateAgainstSchema(
 	message: Record<string, any>,
 	schema: object
 ) {
-	const ajv = new Ajv({ schemaId: 'auto', allErrors: true, verbose: true })
-	ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
-	ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+	const ajv = new Ajv({ allErrors: true, verbose: true })
 
 	if (!ajv.validate(schema, message) && ajv.errors) {
 		onViolation(message, ajv.errors)
@@ -229,6 +227,12 @@ function withTypewriterContext(message: Options = {}): Options {
  * 	call is fired.
  */
 export function {{functionName}}(props: {{typeName}}, options?: Options, callback?: Callback): void {
+
+	{{#if ../isDevelopment}}
+	const schema = {{{rawJSONSchema}}};
+	validateAgainstSchema(props, schema);
+	{{/if}}
+
   const a = analytics();
   if (a) {
     a.track('{{eventName}}', props || {}, {...options,   context: {

--- a/src/languages/templates/typescript/node.hbs
+++ b/src/languages/templates/typescript/node.hbs
@@ -7,7 +7,7 @@
  * 
  * You can install it with: `npm install --save-dev ajv`.
  */
-import Ajv from 'ajv'
+import Ajv, { ErrorObject } from 'ajv'
 {{/if}}
 import AnalyticsNode from 'analytics-node'
 
@@ -125,7 +125,7 @@ export interface Context extends Record<string, any> {
 export type ViolationHandler = (
 	message: TrackMessage<Record<string, any>>,
 	{{!-- Swap the type definitions here so we don't want depend on ajv in production just for this type definition. --}}
-	violations: {{#if isDevelopment}}Ajv.ErrorObject{{else}}any{{/if}}[]
+	violations: {{#if isDevelopment}}ErrorObject{{else}}any{{/if}}[]
 ) => void
 
 /**
@@ -224,11 +224,9 @@ function validateAgainstSchema(
 	message: TrackMessage<Record<string, any>>,
 	schema: object
 ) {
-	const ajv = new Ajv({ schemaId: 'auto', allErrors: true, verbose: true })
-	ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'))
-	ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'))
+	const ajv = new Ajv({ allErrors: true, verbose: true })
 
-	if (!ajv.validate(schema, message) && ajv.errors) {
+	if (!ajv.validate(schema, message.properties) && ajv.errors) {
 		onViolation(message, ajv.errors)
 	}
 }
@@ -267,16 +265,16 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
 	message: TrackMessage<{{typeName}}>,
 	callback?: Callback
 ): void {
-	{{#if ../isDevelopment}}
-	const schema = {{{rawJSONSchema}}}
-	const event = withTypewriterContext({
+  const event = withTypewriterContext({
     ...message,
     event: '{{eventName}}',
     properties: {
       ...message.properties,
     },
   });
-	validateAgainstSchema(event, schema)
+	{{#if ../isDevelopment}}
+	const schema = {{{rawJSONSchema}}};
+	validateAgainstSchema(event, schema);
 	{{/if}}
 
 	const a = analytics()

--- a/src/languages/templates/typescript/node.hbs
+++ b/src/languages/templates/typescript/node.hbs
@@ -267,18 +267,21 @@ function withTypewriterContext<P, T extends TrackMessage<P>>(
 	message: TrackMessage<{{typeName}}>,
 	callback?: Callback
 ): void {
+	{{#if ../isDevelopment}}
+	const schema = {{{rawJSONSchema}}}
+	const event = withTypewriterContext({
+    ...message,
+    event: '{{eventName}}',
+    properties: {
+      ...message.properties,
+    },
+  });
+	validateAgainstSchema(event, schema)
+	{{/if}}
+
 	const a = analytics()
 	if (a) {
-		a.track(
-      withTypewriterContext({
-        ...message,
-        event: '{{eventName}}',
-        properties: {
-          ...message.properties,
-        },
-      }),
-      callback,
-    );
+		a.track(event,callback);
 	} else {
 		throw missingAnalyticsNodeError
 	}


### PR DESCRIPTION
Fixes the validate against schema function calls on dev mode builds for AJS and Node generators.

Refactored the cleanups we do to the JSONSchema and added an extra step for replacing `id` with `$id` per JSONSchema draft 7 spec to play correctly with new versions of AJV.