### PR TITLE
fix: compatibility with node 14-16

### DIFF
--- a/src/api/trackingplans.ts
+++ b/src/api/trackingplans.ts
@@ -1,8 +1,8 @@
 import { debug as debugRegister } from "debug";
 import stringify from "json-stable-stringify";
 import { flow } from "lodash";
-import fs from "node:fs";
-import { promisify } from "node:util";
+import fs from "fs";
+import { promisify } from "util";
 import sortKeys from "sort-keys";
 import { isWrappedError } from "../common";
 import {


### PR DESCRIPTION
Modules with the 'node:' prefix are 18+, which prevents typewriter from running on other (still maintained) versions of Node. 
Admittedly these versions are on borrowed time, 14 is supported until April and 16 is supported until September.
