### PR TITLE
Fix class functions and improve typing

### DIFF
--- a/src/__tests__/commands/__snapshots__/build.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/build.test.ts.snap
@@ -13282,7 +13282,7 @@ export const AnalyticsProvider = ({
     return <Context.Provider value={client}>{children}</Context.Provider>;
 };
 
-export const useAnalytics = () => {
+export const useAnalytics: TypewriterSegmentClient | {} = () => {
     const client = useContext(Context);
     if (!client) {
         console.error(
@@ -13293,9 +13293,8 @@ export const useAnalytics = () => {
         // @ts-ignore
         return {};
     }
-    return {
-        ...client,
-    };
+
+    return client;
 };
 
 "

--- a/src/__tests__/commands/__snapshots__/build.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/build.test.ts.snap
@@ -13282,7 +13282,7 @@ export const AnalyticsProvider = ({
     return <Context.Provider value={client}>{children}</Context.Provider>;
 };
 
-export const useAnalytics: TypewriterSegmentClient | {} = () => {
+export const useAnalytics = (): TypewriterSegmentClient | {} => {
     const client = useContext(Context);
     if (!client) {
         console.error(

--- a/src/languages/templates/typescript/react-native.hbs
+++ b/src/languages/templates/typescript/react-native.hbs
@@ -54,7 +54,6 @@ export const useAnalytics = () => {
     // @ts-ignore
     return {};
   }
-  return {
-    ...client,
-  };
+
+  return client;
 };

--- a/src/languages/templates/typescript/react-native.hbs
+++ b/src/languages/templates/typescript/react-native.hbs
@@ -43,7 +43,7 @@ export const AnalyticsProvider = ({
   return <Context.Provider value={client}>{children}</Context.Provider>;
 };
 
-export const useAnalytics: TypewriterSegmentClient | {} = () => {
+export const useAnalytics = (): TypewriterSegmentClient | {} => {
   const client = useContext(Context);
   if (!client) {
     console.error(

--- a/src/languages/templates/typescript/react-native.hbs
+++ b/src/languages/templates/typescript/react-native.hbs
@@ -43,7 +43,7 @@ export const AnalyticsProvider = ({
   return <Context.Provider value={client}>{children}</Context.Provider>;
 };
 
-export const useAnalytics = () => {
+export const useAnalytics: TypewriterSegmentClient | {} = () => {
   const client = useContext(Context);
   if (!client) {
     console.error(


### PR DESCRIPTION
**Change list**
- Now returning the whole client instance instead of spreading it because the functions from the class instance don't work with the spread operator (e.g. `client.screen()` would complain that it doesn't exist).
- Added explicit return types for the `useAnalytics` hook because it would always be interpreted as `{}` when used otherwise
- Updated the snapshot