### PR TITLE
feat: Reuse validator and publish as internal package [BBEE-1948]

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+@contentful:registry=https://npm.pkg.github.com
+ignore-scripts=true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Contentful Fork
+## Fork
 
 This repository is fork of Segment Typewriter.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## Contentful Fork
+
+This repository is fork of Segment Typewriter.
+
+Summary of changes:
+- Reuse cached Ajv validators during runtime schema validation to avoid recompilation overhead.
+
+Use this package with `npx @contentful/typewriter`.
+
 <p align="center">
 	<br>
 	<br>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,10 +1,11 @@
+const originalConsoleError = console.error
 // eslint-disable-next-line no-undef
 const supressLog = (...args) => {
   // avoid Warning: No API token found at test-env/build
   if (typeof args[0] === 'string' && args[0].includes('API token')) {
     return undefined
   } else {
-    console.error(...args)
+    originalConsoleError(...args)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,21 @@
 {
-  "name": "typewriter",
+  "name": "@contentful/typewriter",
   "version": "9.2.0",
   "description": "A compiler for generating strongly typed analytics clients via Segment Protocols",
-  "repository": "ssh://git@github.com/segmentio/typewriter.git",
   "author": "Oscar Bazaldua <oscar.bazaldua@segment.com>",
   "bin": {
     "typewriter": "./bin/run"
   },
-  "homepage": "https://github.com/segmentio/typewriter",
-  "bugs": "https://github.com/segmentio/typewriter/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/contentful/typewriter"
+  },
+  "publishConfig": {
+    "access": "restricted",
+    "registry": "https://npm.pkg.github.com/"
+  },
+  "homepage": "https://github.com/contentful/typewriter",
+  "bugs": "https://github.com/contentful/typewriter/issues",
   "license": "MIT",
   "main": "dist/index.js",
   "files": [

--- a/src/__tests__/commands/__snapshots__/build.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/build.test.ts.snap
@@ -88,14 +88,23 @@ function setTypewriterOptions(options) {
     onViolation = options.onViolation || onViolation;
 }
 exports.setTypewriterOptions = setTypewriterOptions;
+var ajv = new ajv_1.default({ allErrors: true, verbose: true });
+var validatorCache = new Map();
 /**
     * Validates a message against a JSON Schema using Ajv. If the message
     * is invalid, the \`onViolation\` handler will be called.
     */
 function validateAgainstSchema(message, schema) {
-    var ajv = new ajv_1.default({ allErrors: true, verbose: true });
-    if (!ajv.validate(schema, message.properties) && ajv.errors) {
-        onViolation(message, ajv.errors);
+    var schemaId = schema.$id;
+    var validate = schemaId ? validatorCache.get(schemaId) : undefined;
+    if (!validate) {
+        validate = ajv.compile(schema);
+        if (schemaId) {
+            validatorCache.set(schemaId, validate);
+        }
+    }
+    if (!validate(message.properties) && validate.errors) {
+        onViolation(message, validate.errors);
     }
 }
 /**
@@ -5833,7 +5842,7 @@ export interface NoIDType {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv, { ErrorObject } from 'ajv'
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv'
 
 /**
  * The analytics.js snippet should be available via window.analytics.
@@ -5929,6 +5938,9 @@ export function setTypewriterOptions(options: TypewriterOptions) {
     onViolation = options.onViolation || onViolation
 }
 
+const ajv = new Ajv({ allErrors: true, verbose: true })
+const validatorCache = new Map<string, ValidateFunction>()
+
 /**
     * Validates a message against a JSON Schema using Ajv. If the message
     * is invalid, the \`onViolation\` handler will be called.
@@ -5937,10 +5949,18 @@ function validateAgainstSchema(
     message: Record<string, any>,
     schema: object
 ) {
-    const ajv = new Ajv({ allErrors: true, verbose: true })
+    const schemaId = (schema as { $id?: string }).$id
+    let validate = schemaId ? validatorCache.get(schemaId) : undefined
 
-    if (!ajv.validate(schema, message) && ajv.errors) {
-        onViolation(message, ajv.errors)
+    if (!validate) {
+        validate = ajv.compile(schema)
+        if (schemaId) {
+            validatorCache.set(schemaId, validate)
+        }
+    }
+
+    if (!validate(message) && validate.errors) {
+        onViolation(message, validate.errors as ErrorObject[])
     }
 }
 
@@ -7597,7 +7617,7 @@ export interface NoIDType {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv, { ErrorObject } from 'ajv'
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv'
 
 /**
  * You can install \`@segment/analytics-node\` by following instructions at: 
@@ -7710,6 +7730,9 @@ export function setTypewriterOptions(options: TypewriterOptions) {
     onViolation = options.onViolation || onViolation
 }
 
+const ajv = new Ajv({ allErrors: true, verbose: true })
+const validatorCache = new Map<string, ValidateFunction>()
+
 /**
     * Validates a message against a JSON Schema using Ajv. If the message
     * is invalid, the \`onViolation\` handler will be called.
@@ -7718,10 +7741,18 @@ function validateAgainstSchema(
     message: TrackMessage<Record<string, any>>,
     schema: object
 ) {
-    const ajv = new Ajv({ allErrors: true, verbose: true })
+    const schemaId = (schema as { $id?: string }).$id
+    let validate = schemaId ? validatorCache.get(schemaId) : undefined
 
-    if (!ajv.validate(schema, message.properties) && ajv.errors) {
-        onViolation(message, ajv.errors)
+    if (!validate) {
+        validate = ajv.compile(schema)
+        if (schemaId) {
+            validatorCache.set(schemaId, validate)
+        }
+    }
+
+    if (!validate(message.properties) && validate.errors) {
+        onViolation(message, validate.errors as ErrorObject[])
     }
 }
 
@@ -9445,7 +9476,7 @@ export interface PurpleEventCollided {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv, { ErrorObject } from 'ajv'
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv'
 
 /**
  * You can install \`@segment/analytics-node\` by following instructions at: 
@@ -9558,6 +9589,9 @@ export function setTypewriterOptions(options: TypewriterOptions) {
     onViolation = options.onViolation || onViolation
 }
 
+const ajv = new Ajv({ allErrors: true, verbose: true })
+const validatorCache = new Map<string, ValidateFunction>()
+
 /**
     * Validates a message against a JSON Schema using Ajv. If the message
     * is invalid, the \`onViolation\` handler will be called.
@@ -9566,10 +9600,18 @@ function validateAgainstSchema(
     message: TrackMessage<Record<string, any>>,
     schema: object
 ) {
-    const ajv = new Ajv({ allErrors: true, verbose: true })
+    const schemaId = (schema as { $id?: string }).$id
+    let validate = schemaId ? validatorCache.get(schemaId) : undefined
 
-    if (!ajv.validate(schema, message.properties) && ajv.errors) {
-        onViolation(message, ajv.errors)
+    if (!validate) {
+        validate = ajv.compile(schema)
+        if (schemaId) {
+            validatorCache.set(schemaId, validate)
+        }
+    }
+
+    if (!validate(message.properties) && validate.errors) {
+        onViolation(message, validate.errors as ErrorObject[])
     }
 }
 
@@ -11254,7 +11296,7 @@ export interface PurpleEventCollided {
  * 
  * You can install it with: \`npm install --save-dev ajv\`.
  */
-import Ajv, { ErrorObject } from 'ajv'
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv'
 
 /**
  * You can install \`@segment/analytics-node\` by following instructions at: 
@@ -11367,6 +11409,9 @@ export function setTypewriterOptions(options: TypewriterOptions) {
     onViolation = options.onViolation || onViolation
 }
 
+const ajv = new Ajv({ allErrors: true, verbose: true })
+const validatorCache = new Map<string, ValidateFunction>()
+
 /**
     * Validates a message against a JSON Schema using Ajv. If the message
     * is invalid, the \`onViolation\` handler will be called.
@@ -11375,10 +11420,18 @@ function validateAgainstSchema(
     message: TrackMessage<Record<string, any>>,
     schema: object
 ) {
-    const ajv = new Ajv({ allErrors: true, verbose: true })
+    const schemaId = (schema as { $id?: string }).$id
+    let validate = schemaId ? validatorCache.get(schemaId) : undefined
 
-    if (!ajv.validate(schema, message.properties) && ajv.errors) {
-        onViolation(message, ajv.errors)
+    if (!validate) {
+        validate = ajv.compile(schema)
+        if (schemaId) {
+            validatorCache.set(schemaId, validate)
+        }
+    }
+
+    if (!validate(message.properties) && validate.errors) {
+        onViolation(message, validate.errors as ErrorObject[])
     }
 }
 

--- a/src/languages/templates/typescript/analytics-js.hbs
+++ b/src/languages/templates/typescript/analytics-js.hbs
@@ -7,7 +7,7 @@
  * 
  * You can install it with: `npm install --save-dev ajv`.
  */
-import Ajv, { ErrorObject } from 'ajv'
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv'
 {{/if}}
 
 /**
@@ -110,6 +110,9 @@ export function setTypewriterOptions(options: TypewriterOptions) {
 }
 
 {{#if isDevelopment}}
+const ajv = new Ajv({ allErrors: true, verbose: true })
+const validatorCache = new Map<string, ValidateFunction>()
+
 /**
 	* Validates a message against a JSON Schema using Ajv. If the message
 	* is invalid, the `onViolation` handler will be called.
@@ -118,10 +121,18 @@ function validateAgainstSchema(
 	message: Record<string, any>,
 	schema: object
 ) {
-	const ajv = new Ajv({ allErrors: true, verbose: true })
+	const schemaId = (schema as { $id?: string }).$id
+	let validate = schemaId ? validatorCache.get(schemaId) : undefined
 
-	if (!ajv.validate(schema, message) && ajv.errors) {
-		onViolation(message, ajv.errors)
+	if (!validate) {
+		validate = ajv.compile(schema)
+		if (schemaId) {
+			validatorCache.set(schemaId, validate)
+		}
+	}
+
+	if (!validate(message) && validate.errors) {
+		onViolation(message, validate.errors as ErrorObject[])
 	}
 }
 {{/if}}

--- a/src/languages/templates/typescript/node.hbs
+++ b/src/languages/templates/typescript/node.hbs
@@ -7,7 +7,7 @@
  * 
  * You can install it with: `npm install --save-dev ajv`.
  */
-import Ajv, { ErrorObject } from 'ajv'
+import Ajv, { ErrorObject, ValidateFunction } from 'ajv'
 {{/if}}
 
 /**
@@ -127,6 +127,9 @@ export function setTypewriterOptions(options: TypewriterOptions) {
 }
 
 {{#if isDevelopment}}
+const ajv = new Ajv({ allErrors: true, verbose: true })
+const validatorCache = new Map<string, ValidateFunction>()
+
 /**
 	* Validates a message against a JSON Schema using Ajv. If the message
 	* is invalid, the `onViolation` handler will be called.
@@ -135,10 +138,18 @@ function validateAgainstSchema(
 	message: TrackMessage<Record<string, any>>,
 	schema: object
 ) {
-	const ajv = new Ajv({ allErrors: true, verbose: true })
+	const schemaId = (schema as { $id?: string }).$id
+	let validate = schemaId ? validatorCache.get(schemaId) : undefined
 
-	if (!ajv.validate(schema, message.properties) && ajv.errors) {
-		onViolation(message, ajv.errors)
+	if (!validate) {
+		validate = ajv.compile(schema)
+		if (schemaId) {
+			validatorCache.set(schemaId, validate)
+		}
+	}
+
+	if (!validate(message.properties) && validate.errors) {
+		onViolation(message, validate.errors as ErrorObject[])
 	}
 }
 {{/if}}


### PR DESCRIPTION
- Reuse the validator so that it is not recreated every time an event is being tracked (which can be a performance bottleneck for large amounts of events)