### PR TITLE
adds messageId into TrackMessage for node template

### DIFF
--- a/src/__tests__/commands/__snapshots__/build.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/build.test.ts.snap
@@ -7619,7 +7619,7 @@ type Identity =
 export type TrackMessage<PropertiesType> = Omit<
     TrackParams,
     'event' | 'properties'
-> & { event?: string, properties: PropertiesType } & Identity
+> & { messageId?: string, event?: string, properties: PropertiesType } & Identity
 
 /** The callback exposed by analytics-node. */
 export type Callback = Parameters<Analytics['track']>[1]
@@ -9467,7 +9467,7 @@ type Identity =
 export type TrackMessage<PropertiesType> = Omit<
     TrackParams,
     'event' | 'properties'
-> & { event?: string, properties: PropertiesType } & Identity
+> & { messageId?: string, event?: string, properties: PropertiesType } & Identity
 
 /** The callback exposed by analytics-node. */
 export type Callback = Parameters<Analytics['track']>[1]
@@ -11276,7 +11276,7 @@ type Identity =
 export type TrackMessage<PropertiesType> = Omit<
     TrackParams,
     'event' | 'properties'
-> & { event?: string, properties: PropertiesType } & Identity
+> & { messageId?: string, event?: string, properties: PropertiesType } & Identity
 
 /** The callback exposed by analytics-node. */
 export type Callback = Parameters<Analytics['track']>[1]

--- a/src/__tests__/commands/__snapshots__/production.test.ts.snap
+++ b/src/__tests__/commands/__snapshots__/production.test.ts.snap
@@ -2467,7 +2467,7 @@ type Identity =
 export type TrackMessage<PropertiesType> = Omit<
     TrackParams,
     'event' | 'properties'
-> & { event?: string, properties: PropertiesType } & Identity
+> & { messageId?: string, event?: string, properties: PropertiesType } & Identity
 
 /** The callback exposed by analytics-node. */
 export type Callback = Parameters<Analytics['track']>[1]

--- a/src/languages/templates/typescript/node.hbs
+++ b/src/languages/templates/typescript/node.hbs
@@ -30,7 +30,7 @@ type Identity =
 export type TrackMessage<PropertiesType> = Omit<
   TrackParams,
   'event' | 'properties'
-> & { event?: string, properties: PropertiesType } & Identity
+> & { messageId?: string, event?: string, properties: PropertiesType } & Identity
 
 /** The callback exposed by analytics-node. */
 export type Callback = Parameters<Analytics['track']>[1]


### PR DESCRIPTION
Resolves https://github.com/segmentio/typewriter/issues/279

I noticed that a past contributor had made this change, which was later removed (deliberately) by an SDK upgrade.

I am fairly sure the ~~underlying untyped SDK~~ newer versions of the SDK allows passing the messageId field. If messageId is not provided it will generate one.

Thanks for your consideration.
